### PR TITLE
Fix polling cleanup in Generate page

### DIFF
--- a/src/pages/workspace/Generate.tsx
+++ b/src/pages/workspace/Generate.tsx
@@ -8,7 +8,7 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
-import { Plus, Menu } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -22,11 +22,12 @@ import { useTrackRecovery } from "@/hooks/useTrackRecovery";
 import { useAudioPlayer } from "@/contexts/AudioPlayerContext";
 import { supabase } from "@/integrations/supabase/client";
 import { logInfo } from "@/utils/logger";
+import type { Track } from "@/services/api.service";
 
 const Generate = () => {
   const { tracks, isLoading, deleteTrack, refreshTracks } = useTracks();
   const { currentTrack } = useAudioPlayer();
-  const [selectedTrack, setSelectedTrack] = useState<any>(null);
+  const [selectedTrack, setSelectedTrack] = useState<Track | null>(null);
   const [showGenerator, setShowGenerator] = useState(false);
   const [isPolling, setIsPolling] = useState(false);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
@@ -51,13 +52,19 @@ const Generate = () => {
       logInfo('Track completed - refreshing list', 'Generate', { trackId });
       refreshTracks();
       setIsPolling(false);
-      if (pollingRef.current) clearInterval(pollingRef.current);
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
     },
     onTrackFailed: (trackId, error) => {
       logInfo('Track failed - refreshing list', 'Generate', { trackId, error });
       refreshTracks();
       setIsPolling(false);
-      if (pollingRef.current) clearInterval(pollingRef.current);
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
     },
     enabled: true,
   });
@@ -71,12 +78,15 @@ const Generate = () => {
 
   const handleTrackGenerated = () => {
     setShowGenerator(false);
-    if (pollingRef.current) clearInterval(pollingRef.current);
 
     initialTrackCount.current = tracks.length;
     setIsPolling(true);
 
-    // Start polling, but clear any existing timers first
+    if (pollingRef.current) {
+      return;
+    }
+
+    // Start polling if no existing timer
     pollingRef.current = setInterval(() => {
       refreshTracks();
     }, 2500); // Poll every 2.5 seconds
@@ -85,28 +95,38 @@ const Generate = () => {
   useEffect(() => {
     if (!isPolling) return;
 
-    // Stop polling if a new track has been added
-    if (tracks.length > initialTrackCount.current) {
-      const newTrack = tracks.find(t => !tracks.slice(initialTrackCount.current).some(it => it.id === t.id));
-      if(newTrack || tracks.some(t => t.status === 'processing')) {
-        if (pollingRef.current) clearInterval(pollingRef.current);
-        setIsPolling(false);
+    const hasNewTrack =
+      tracks.length > initialTrackCount.current &&
+      tracks.slice(initialTrackCount.current).some((track) => Boolean(track));
+    const hasProcessingTracks = tracks.some(t => t.status === 'processing');
+
+    if (hasNewTrack || hasProcessingTracks) {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
       }
+      setIsPolling(false);
     }
 
     // Failsafe timeout after 1 minute
     const timeout = setTimeout(() => {
-      if (pollingRef.current) clearInterval(pollingRef.current);
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
       setIsPolling(false);
     }, 60000);
 
     return () => {
       clearTimeout(timeout);
-      if (pollingRef.current) clearInterval(pollingRef.current);
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
     };
-  }, [tracks, isPolling, initialTrackCount]);
+  }, [tracks, isPolling]);
 
-  const handleTrackSelect = (track: any) => {
+  const handleTrackSelect = (track: Track) => {
     setSelectedTrack(track);
   };
 

--- a/src/pages/workspace/__tests__/Generate.test.tsx
+++ b/src/pages/workspace/__tests__/Generate.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { ReactNode, ButtonHTMLAttributes } from "react";
+import Generate from "../Generate";
+import type { Track } from "@/services/api.service";
+
+const refreshTracksMock = vi.fn();
+const deleteTrackMock = vi.fn();
+
+type UseTracksReturn = {
+  tracks: Track[];
+  isLoading: boolean;
+  deleteTrack: typeof deleteTrackMock;
+  refreshTracks: typeof refreshTracksMock;
+};
+
+let useTracksReturn: UseTracksReturn = {
+  tracks: [],
+  isLoading: false,
+  deleteTrack: deleteTrackMock,
+  refreshTracks: refreshTracksMock,
+};
+
+vi.mock("@/hooks/useTracks", () => ({
+  useTracks: () => useTracksReturn,
+}));
+
+vi.mock("@/components/LazyComponents", () => ({
+  MusicGeneratorLazy: ({ onTrackGenerated }: { onTrackGenerated?: () => void }) => (
+    <button data-testid="start-generation" onClick={() => onTrackGenerated?.()}>
+      Generate
+    </button>
+  ),
+  TracksListLazy: ({ tracks }: { tracks: Track[] }) => (
+    <div data-testid="tracks-list">{tracks.length}</div>
+  ),
+  DetailPanelLazy: ({ track }: { track: Track | null }) => (
+    <div data-testid="detail-panel">{track ? track.title : null}</div>
+  ),
+}));
+
+vi.mock("@/hooks/useTrackSync", () => ({
+  useTrackSync: vi.fn(),
+}));
+
+vi.mock("@/hooks/useTrackRecovery", () => ({
+  useTrackRecovery: vi.fn(),
+}));
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => true,
+}));
+
+vi.mock("@/contexts/AudioPlayerContext", () => ({
+  useAudioPlayer: () => ({ currentTrack: null }),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/drawer", () => ({
+  Drawer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ ...props }) => <div data-testid="polling-skeleton" {...props} />,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    },
+  },
+}));
+
+describe("Generate polling interval", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    refreshTracksMock.mockReset();
+    deleteTrackMock.mockReset();
+    useTracksReturn = {
+      tracks: [],
+      isLoading: false,
+      deleteTrack: deleteTrackMock,
+      refreshTracks: refreshTracksMock,
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("clears the polling interval when a new track appears", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    const { rerender } = render(<Generate />);
+
+    fireEvent.click(screen.getByTestId("start-generation"));
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByTestId("polling-skeleton")).toBeInTheDocument();
+
+    vi.advanceTimersByTime(2500);
+    expect(refreshTracksMock).toHaveBeenCalledTimes(1);
+
+    const newTrack: Track = {
+      id: "track-1",
+      title: "New Track",
+      audio_url: null,
+      status: "pending",
+      created_at: new Date().toISOString(),
+      prompt: "Prompt",
+      improved_prompt: null,
+      duration: null,
+      duration_seconds: null,
+      error_message: null,
+      cover_url: null,
+      video_url: null,
+      suno_id: null,
+      model_name: null,
+      created_at_suno: null,
+      lyrics: null,
+      style_tags: null,
+      has_vocals: null,
+      provider: null,
+    };
+
+    await act(async () => {
+      useTracksReturn = {
+        ...useTracksReturn,
+        tracks: [newTrack],
+      };
+
+      rerender(<Generate />);
+    });
+
+    expect(screen.getByTestId("tracks-list").textContent).toBe("1");
+
+    expect(screen.queryByTestId("polling-skeleton")).not.toBeInTheDocument();
+
+    refreshTracksMock.mockClear();
+    vi.advanceTimersByTime(2500);
+    expect(refreshTracksMock).not.toHaveBeenCalled();
+
+    setIntervalSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- tighten the Generate page state typing and guard against creating duplicate polling timers
- update the polling effect to stop once new tracks appear and ensure timers are cleared
- add a Vitest test covering interval cleanup after a new track is returned

## Testing
- npx vitest run src/pages/workspace/__tests__/Generate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e668d17f30832f9733417703ccfa0d