### PR TITLE
Fix TypeScript test failures after hook and type updates

### DIFF
--- a/src/components/__tests__/AuthForm.test.tsx
+++ b/src/components/__tests__/AuthForm.test.tsx
@@ -77,7 +77,7 @@ describe('AuthForm', () => {
       await userEvent.click(signUpTab);
 
       // Wait for the sign-up button to be visible, confirming the tab switch
-      const signUpButton = await screen.findByRole('button', { name: /sign up/i, type: 'submit' });
+      const signUpButton = await screen.findByRole('button', { name: /sign up/i });
       expect(signUpButton).toBeInTheDocument();
     });
 
@@ -86,7 +86,7 @@ describe('AuthForm', () => {
       const signUpTab = screen.getByRole('tab', { name: /sign up/i });
       await userEvent.click(signUpTab);
 
-      const submitButton = await screen.findByRole('button', { name: /sign up/i, type: 'submit' });
+      const submitButton = await screen.findByRole('button', { name: /sign up/i });
       const emailInput = screen.getByPlaceholderText('Email');
       const passwordInput = screen.getByPlaceholderText('Password');
 
@@ -106,7 +106,7 @@ describe('AuthForm', () => {
       const signUpTab = screen.getByRole('tab', { name: /sign up/i });
       await userEvent.click(signUpTab);
 
-      const submitButton = await screen.findByRole('button', { name: /sign up/i, type: 'submit' });
+      const submitButton = await screen.findByRole('button', { name: /sign up/i });
       const emailInput = screen.getByPlaceholderText('Email');
       const passwordInput = screen.getByPlaceholderText('Password');
 
@@ -132,7 +132,7 @@ describe('AuthForm', () => {
       const signUpTab = screen.getByRole('tab', { name: /sign up/i });
       await userEvent.click(signUpTab);
 
-      const submitButton = await screen.findByRole('button', { name: /sign up/i, type: 'submit' });
+      const submitButton = await screen.findByRole('button', { name: /sign up/i });
       const emailInput = screen.getByPlaceholderText('Email') as HTMLInputElement;
       const passwordInput = screen.getByPlaceholderText('Password') as HTMLInputElement;
 

--- a/src/components/__tests__/MusicGenerator.test.tsx
+++ b/src/components/__tests__/MusicGenerator.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MusicGenerator } from '../MusicGenerator';
@@ -20,6 +20,10 @@ const mockUseMusicGeneration = {
   setStyleTags: vi.fn(),
   generateMusic: vi.fn(),
   improvePrompt: vi.fn(),
+  addStyleTag: vi.fn(),
+  removeStyleTag: vi.fn(),
+  canGenerate: true,
+  isValidPrompt: true,
 };
 
 vi.mock('@/hooks/useMusicGeneration', () => ({
@@ -48,6 +52,10 @@ vi.mock('@/hooks/use-toast', () => ({
 describe('MusicGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseMusicGeneration.prompt = '';
+    mockUseMusicGeneration.isGenerating = false;
+    mockUseMusicGeneration.isImproving = false;
+    mockUseMusicGeneration.styleTags = [];
   });
 
   describe('Rendering', () => {

--- a/src/components/__tests__/TrackCard.test.tsx
+++ b/src/components/__tests__/TrackCard.test.tsx
@@ -129,6 +129,7 @@ describe('TrackCard', () => {
     });
 
     it('renders error message for missing track', () => {
+      // @ts-expect-error - testing component fallback with null track
       render(<TrackCard track={null} />);
 
       expect(screen.getByRole('alert')).toBeInTheDocument();

--- a/src/components/player/__tests__/GlobalAudioPlayer.test.tsx
+++ b/src/components/player/__tests__/GlobalAudioPlayer.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { GlobalAudioPlayer } from '../GlobalAudioPlayer';
 import { useAudioPlayer, useAudioPlayerSafe } from '@/contexts/AudioPlayerContext';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { Track } from '@/types/track';
+import { AudioPlayerTrack } from '@/types/track';
 
 // Mock the hooks
 vi.mock('@/contexts/AudioPlayerContext');
@@ -12,9 +12,9 @@ vi.mock('@/hooks/useMediaSession', () => ({
   useMediaSession: vi.fn(),
 }));
 
-const mockUseAudioPlayer = useAudioPlayer as vi.Mock;
-const mockUseAudioPlayerSafe = useAudioPlayerSafe as vi.Mock;
-const mockUseIsMobile = useIsMobile as vi.Mock;
+const mockUseAudioPlayer = vi.mocked(useAudioPlayer);
+const mockUseAudioPlayerSafe = vi.mocked(useAudioPlayerSafe);
+const mockUseIsMobile = vi.mocked(useIsMobile);
 
 const defaultMockData = {
   currentTrack: {
@@ -23,7 +23,7 @@ const defaultMockData = {
     audio_url: 'https://example.com/audio.mp3',
     cover_url: 'https://example.com/cover.jpg',
     style_tags: ['rock', 'indie'],
-  } as Track,
+  } as AudioPlayerTrack,
   isPlaying: true,
   currentTime: 30,
   duration: 180,

--- a/src/components/tracks/TrackListItem.tsx
+++ b/src/components/tracks/TrackListItem.tsx
@@ -13,7 +13,7 @@ import {
   Music,
   Headphones
 } from 'lucide-react';
-import { useAudioPlayer, useAudioPlayerSafe } from '@/hooks/useAudioPlayer';
+import { useAudioPlayerSafe } from '@/hooks/useAudioPlayer';
 import { useToast } from '@/hooks/use-toast';
 import { useTrackLike } from '@/hooks/useTrackLike';
 import { cn } from '@/lib/utils';
@@ -42,12 +42,9 @@ export const TrackListItem: React.FC<TrackListItemProps> = memo(({
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const itemRef = useRef<HTMLDivElement>(null);
   
-  const { 
-    currentTrack, 
-    isPlaying, 
-    playTrack, 
-    pauseTrack 
-  } = useAudioPlayerSafe();
+  const audioPlayer = useAudioPlayerSafe();
+  const currentTrack = audioPlayer?.currentTrack;
+  const isPlaying = audioPlayer?.isPlaying ?? false;
 
   const { toast } = useToast();
   
@@ -154,16 +151,16 @@ export const TrackListItem: React.FC<TrackListItemProps> = memo(({
 
   const handlePlayClick = useCallback(() => {
     if (!track.audio_url) return;
-    
-    const audioPlayerTrack = convertToAudioPlayerTrack(track);
-    if (!audioPlayerTrack) return;
 
-    if (isCurrentTrack && isPlaying) {
-      pauseTrack();
+    const audioPlayerTrack = convertToAudioPlayerTrack(track);
+    if (!audioPlayerTrack || !audioPlayer) return;
+
+    if (audioPlayer.currentTrack?.id === track.id && audioPlayer.isPlaying) {
+      audioPlayer.pauseTrack();
     } else {
-      playTrack(audioPlayerTrack);
+      audioPlayer.playTrack(audioPlayerTrack);
     }
-  }, [track, isCurrentTrack, isPlaying, playTrack, pauseTrack]);
+  }, [audioPlayer, track]);
 
   const formatDuration = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);

--- a/src/components/tracks/__tests__/TrackListItem.test.tsx
+++ b/src/components/tracks/__tests__/TrackListItem.test.tsx
@@ -5,7 +5,6 @@ import { useAudioPlayer, useAudioPlayerSafe } from '@/hooks/useAudioPlayer';
 import { useToast } from '@/hooks/use-toast';
 import { useTrackLike } from '@/hooks/useTrackLike';
 import { DisplayTrack } from '@/types/track';
-import { supabase } from '@/integrations/supabase/client';
 
 // Mock the source of the hooks
 vi.mock('@/contexts/AudioPlayerContext', () => ({
@@ -32,7 +31,6 @@ describe('TrackListItem', () => {
     created_at: '2024-01-15T12:00:00Z',
     style_tags: ['rock', 'indie'],
     like_count: 5,
-    is_liked: false,
   };
 
   const playTrackMock = vi.fn();
@@ -40,24 +38,29 @@ describe('TrackListItem', () => {
   const toastMock = vi.fn();
   const toggleLikeMock = vi.fn();
 
+  const mockedUseAudioPlayer = vi.mocked(useAudioPlayer);
+  const mockedUseAudioPlayerSafe = vi.mocked(useAudioPlayerSafe);
+  const mockedUseToast = vi.mocked(useToast);
+  const mockedUseTrackLike = vi.mocked(useTrackLike);
+
   beforeEach(() => {
     vi.clearAllMocks();
-    (useAudioPlayer as vi.Mock).mockReturnValue({
+    mockedUseAudioPlayer.mockReturnValue({
       currentTrack: null,
       isPlaying: false,
       playTrack: playTrackMock,
       pauseTrack: pauseTrackMock,
     });
-    (useAudioPlayerSafe as vi.Mock).mockReturnValue({
+    mockedUseAudioPlayerSafe.mockReturnValue({
       currentTrack: null,
       isPlaying: false,
       playTrack: playTrackMock,
       pauseTrack: pauseTrackMock,
     });
-    (useToast as vi.Mock).mockReturnValue({
+    mockedUseToast.mockReturnValue({
       toast: toastMock,
     });
-    (useTrackLike as vi.Mock).mockReturnValue({
+    mockedUseTrackLike.mockReturnValue({
       isLiked: false,
       likeCount: 5,
       toggleLike: toggleLikeMock,
@@ -121,9 +124,11 @@ describe('TrackListItem', () => {
     });
 
     it('shows pause button for currently playing track', async () => {
-      (useAudioPlayerSafe as vi.Mock).mockReturnValue({
+      mockedUseAudioPlayerSafe.mockReturnValue({
         currentTrack: { id: 'track-1' },
         isPlaying: true,
+        playTrack: playTrackMock,
+        pauseTrack: pauseTrackMock,
       });
       const { getByTestId } = setup();
       fireEvent.mouseEnter(getByTestId(`track-list-item-${mockTrack.id}`));

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -20,7 +20,7 @@ describe('formatDuration', () => {
   });
 
   it('handles null and undefined', () => {
-    expect(formatDuration(null)).toBe('—');
+    expect(formatDuration(null as unknown as number)).toBe('—');
     expect(formatDuration(undefined)).toBe('—');
     expect(formatDuration(NaN)).toBe('—');
   });
@@ -85,8 +85,8 @@ describe('formatFileSize', () => {
   });
 
   it('handles null and undefined gracefully', () => {
-    expect(formatFileSize(null)).toBe('0 Б');
-    expect(formatFileSize(undefined)).toBe('0 Б');
+    expect(formatFileSize(null as unknown as number)).toBe('0 Б');
+    expect(formatFileSize(undefined as unknown as number)).toBe('0 Б');
   });
 
   it('handles negative values gracefully', () => {

--- a/src/utils/trackVersions.ts
+++ b/src/utils/trackVersions.ts
@@ -63,27 +63,6 @@ export interface TrackWithVersions {
 const isTrackMetadata = (metadata: unknown): metadata is TrackMetadata =>
   typeof metadata === 'object' && metadata !== null;
 
-const isSunoMetadataEntry = (entry: unknown): entry is SunoMetadataEntry =>
-  typeof entry === 'object' && entry !== null;
-
-const hasAudioSource = (entry: SunoMetadataEntry | undefined): entry is SunoMetadataEntry =>
-  Boolean(entry && (entry.audioUrl || entry.audio_url || entry.stream_audio_url));
-
-const resolveAudioUrl = (entry: SunoMetadataEntry): string =>
-  entry.audioUrl || entry.audio_url || entry.stream_audio_url || '';
-
-const resolveImageUrl = (entry: SunoMetadataEntry, fallback?: string | null): string | undefined =>
-  entry.image_url || entry.imageUrl || fallback || undefined;
-
-const resolveVideoUrl = (entry: SunoMetadataEntry): string | undefined =>
-  entry.video_url || entry.videoUrl || undefined;
-
-const resolveDuration = (entry: SunoMetadataEntry): number | undefined =>
-  entry.duration ?? entry.duration_seconds ?? undefined;
-
-const resolveLyrics = (entry: SunoMetadataEntry, fallback?: string | null): string | undefined =>
-  entry.lyric || entry.lyrics || fallback || undefined;
-
 /**
  * Loads a track and all its versions from the database
  * Returns an array where first element is the main track, followed by all versions


### PR DESCRIPTION
## Summary
- align authentication and generator tests with updated hook contracts to satisfy strict TypeScript checks
- harden the track list item against missing audio player context and update related tests and utilities
- refresh type-focused unit tests and clean up unused metadata helpers for stricter compile-time validation

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e685494c90832fb892dfcd84f590b6