### PR TITLE
Fix Suno credit display and music generation workflow

### DIFF
--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -123,8 +123,8 @@ export class ApiService {
       trackId: request.trackId,
       title: request.title || request.prompt.substring(0, 50),
       prompt: request.prompt,
-      tags: request.styleTags?.join(', ') || '',
-      make_instrumental: !request.hasVocals,
+      tags: request.styleTags ?? [],
+      make_instrumental: request.hasVocals === false,
       model_version: request.modelVersion || 'chirp-v3-5',
       wait_audio: false,
     };

--- a/supabase/functions/_shared/supabase.ts
+++ b/supabase/functions/_shared/supabase.ts
@@ -1,0 +1,54 @@
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+
+/**
+ * Shared helpers for configuring Supabase clients inside Edge Functions.
+ * Normalises environment variable names and centralises error handling so
+ * generation-related functions don't silently run without credentials.
+ */
+
+export const getSupabaseUrl = (): string => Deno.env.get("SUPABASE_URL") ?? "";
+
+export const getSupabaseServiceRoleKey = (): string =>
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+    ?? Deno.env.get("SUPABASE_SERVICE_ROLE")
+    ?? "";
+
+export const getSupabaseAnonKey = (): string => Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+
+export const ensureSupabaseUrl = (): string => {
+  const supabaseUrl = getSupabaseUrl();
+  if (!supabaseUrl) {
+    throw new Error("SUPABASE_URL is not configured");
+  }
+  return supabaseUrl;
+};
+
+export const ensureServiceRoleKey = (): string => {
+  const serviceRoleKey = getSupabaseServiceRoleKey();
+  if (!serviceRoleKey) {
+    throw new Error("Supabase service role credentials are not configured");
+  }
+  return serviceRoleKey;
+};
+
+export const ensureAnonKey = (): string => {
+  const anonKey = getSupabaseAnonKey();
+  if (!anonKey) {
+    throw new Error("Supabase anonymous key is not configured");
+  }
+  return anonKey;
+};
+
+export const createSupabaseAdminClient = (): SupabaseClient => {
+  const supabaseUrl = ensureSupabaseUrl();
+  const serviceRoleKey = ensureServiceRoleKey();
+  return createClient(supabaseUrl, serviceRoleKey);
+};
+
+export const createSupabaseUserClient = (token: string): SupabaseClient => {
+  const supabaseUrl = ensureSupabaseUrl();
+  const anonKey = ensureAnonKey();
+  return createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+};

--- a/supabase/functions/generate-music/index.ts
+++ b/supabase/functions/generate-music/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { withRateLimit, createSecurityHeaders } from "../_shared/security.ts";
 import { validateRequest, validationSchemas } from "../_shared/validation.ts";
+import { createSupabaseAdminClient, createSupabaseUserClient } from "../_shared/supabase.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -31,11 +31,7 @@ const mainHandler = async (req: Request): Promise<Response> => {
     }
 
     const token = authHeader.replace('Bearer ', '')
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
-      { global: { headers: { Authorization: `Bearer ${token}` } } }
-    )
+    const supabaseClient = createSupabaseUserClient(token)
 
     const { data: { user }, error: authError } = await supabaseClient.auth.getUser()
     if (authError || !user) {
@@ -58,9 +54,7 @@ const mainHandler = async (req: Request): Promise<Response> => {
     }
 
     // Initialize Supabase client for updating track status
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-    const supabase = createClient(supabaseUrl, supabaseKey);
+    const supabase = createSupabaseAdminClient();
 
     console.log(`Starting music generation for track ${trackId} with prompt: ${prompt}`);
 

--- a/supabase/functions/migrate-tracks-to-storage/index.ts
+++ b/supabase/functions/migrate-tracks-to-storage/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { createCorsHeaders } from "../_shared/cors.ts";
 import { downloadAndUploadAudio, downloadAndUploadCover, downloadAndUploadVideo } from "../_shared/storage.ts";
+import { createSupabaseAdminClient } from "../_shared/supabase.ts";
 
 const corsHeaders = createCorsHeaders();
 
@@ -13,10 +13,7 @@ serve(async (req: Request) => {
   try {
     console.log('🔄 [MIGRATE] Starting migration of old tracks to Storage...');
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const supabase = createSupabaseAdminClient();
 
     // Statistics
     let totalTracks = 0;

--- a/supabase/functions/stems-callback/index.ts
+++ b/supabase/functions/stems-callback/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.3';
 import { withRateLimit, createSecurityHeaders } from "../_shared/security.ts";
 import { createCorsHeaders, handleCorsPreflightRequest } from "../_shared/cors.ts";
+import { createSupabaseAdminClient } from "../_shared/supabase.ts";
 
 const corsHeaders = {
   ...createCorsHeaders(),
@@ -45,9 +45,7 @@ const mainHandler = async (req: Request) => {
     const payload = JSON.parse(bodyText);
     console.log('Stems callback payload:', JSON.stringify(payload, null, 2));
 
-    const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-    const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const supabase = createSupabaseAdminClient();
 
     if (payload.code !== 200 || !payload.data) {
       console.error('Invalid stems callback payload:', payload);

--- a/supabase/functions/suno-callback/index.ts
+++ b/supabase/functions/suno-callback/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { withRateLimit, createSecurityHeaders } from "../_shared/security.ts";
 import { createCorsHeaders, handleCorsPreflightRequest } from "../_shared/cors.ts";
+import { createSupabaseAdminClient } from "../_shared/supabase.ts";
 
 const corsHeaders = {
   ...createCorsHeaders(),
@@ -25,9 +25,7 @@ const mainHandler = async (req: Request) => {
   }
 
   try {
-    const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-    const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const supabase = createSupabaseAdminClient();
 
     // Check content length before reading
     const contentLength = req.headers.get('content-length');


### PR DESCRIPTION
## Summary
- prioritize the Suno provider when loading balances and capture provider-specific errors for better UI feedback
- send structured tags to the generate function and only request instrumentals when vocals are explicitly disabled
- refactor the music generation hook to remove the broken internal prompt state, prevent overlapping jobs, and keep polling active until Suno completes

## Testing
- npm run test -- --runInBand MusicGenerator *(fails: repository has no "test" script)*
- npm run lint *(fails: pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6b511b540832f9e13fb600a0f63b8