### PR TITLE
Avoid sending Supabase diagnostic header on cross-origin requests

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -17,6 +17,28 @@ const resolveStorage = (): Storage | undefined => {
   }
 };
 
+const resolveGlobalHeaders = (): Record<string, string> => {
+  if (typeof window === "undefined") {
+    return { "x-app-environment": appEnv.appEnv };
+  }
+
+  try {
+    const supabaseHost = new URL(appEnv.supabaseUrl).host;
+
+    if (window.location.host === supabaseHost) {
+      return { "x-app-environment": appEnv.appEnv };
+    }
+  } catch (error) {
+    logError(
+      "Failed to resolve Supabase URL when building headers",
+      error instanceof Error ? error : new Error(String(error)),
+      "SupabaseClient",
+    );
+  }
+
+  return {};
+};
+
 const clientOptions: SupabaseClientOptions<"public"> = {
   auth: {
     storage: resolveStorage(),
@@ -25,9 +47,7 @@ const clientOptions: SupabaseClientOptions<"public"> = {
     detectSessionInUrl: true,
   },
   global: {
-    headers: {
-      "x-app-environment": appEnv.appEnv,
-    },
+    headers: resolveGlobalHeaders(),
   },
 };
 


### PR DESCRIPTION
## Summary
- add a resolver that only attaches the Supabase diagnostic header when the request originates from the same host or from server-side code
- log failures to parse the Supabase URL and fall back to no extra headers to avoid blocking the request

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e6dde28a54832f8166072c7991ed48