### PR TITLE
Remove virtual flag from Sentry mocks

### DIFF
--- a/src/components/__tests__/TrackCard.test.tsx
+++ b/src/components/__tests__/TrackCard.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/hooks/useTrackLike', () => ({
 vi.mock('@sentry/react', () => ({
   withErrorBoundary: (component: unknown) => component,
   captureException: vi.fn(),
-}), { virtual: true });
+}));
 
 vi.mock('@/utils/logger', () => ({
   logError: vi.fn(),

--- a/src/components/__tests__/TrackVersions.test.tsx
+++ b/src/components/__tests__/TrackVersions.test.tsx
@@ -26,7 +26,7 @@ vi.mock('@/hooks/useHapticFeedback', () => ({
 vi.mock('@sentry/react', () => ({
   withScope: vi.fn(),
   captureException: vi.fn(),
-}), { virtual: true });
+}));
 
 const toastMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 vi.mock('sonner', () => ({

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -6,7 +6,7 @@ vi.mock('@sentry/react', () => ({
   captureException: vi.fn(),
   withScope: vi.fn(),
   configureScope: vi.fn(),
-}), { virtual: true });
+}));
 
 // Mock i18next
 vi.mock('react-i18next', () => ({

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@sentry/react', () => ({
   captureException: vi.fn(),
-}), { virtual: true });
+}));
 
 const originalFetch = global.fetch;
 


### PR DESCRIPTION
## Summary
- remove the extra virtual flag argument from the mocked @sentry/react module in tests and shared setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7016caa4c832f8e44236985469877