### PR TITLE
Adjust Supabase mock signatures in TrackVersions tests

### DIFF
--- a/src/components/__tests__/TrackVersions.test.tsx
+++ b/src/components/__tests__/TrackVersions.test.tsx
@@ -39,14 +39,14 @@ const supabaseMocks = vi.hoisted(() => {
     deleteEq: vi.fn(),
     update: vi.fn(() => ({ eq: obj.updateEq } as const)),
     delete: vi.fn(() => ({ eq: obj.deleteEq } as const)),
-    from: vi.fn(() => ({ update: obj.update, delete: obj.delete })),
+    from: vi.fn((table: string) => ({ update: obj.update, delete: obj.delete })),
   };
   return obj;
 });
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
-    from: (...args: unknown[]) => supabaseMocks.from(...args),
+    from: supabaseMocks.from,
   },
 }));
 


### PR DESCRIPTION
## Summary
- update the TrackVersions test supabase mock to accept an explicit table argument
- ensure the client mock uses the hoisted from function directly so signatures align

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7027cac68832fb94660886862d8f6