### PR TITLE
Expand audio player context mocks in GlobalAudioPlayer tests

### DIFF
--- a/src/components/player/__tests__/GlobalAudioPlayer.test.tsx
+++ b/src/components/player/__tests__/GlobalAudioPlayer.test.tsx
@@ -4,6 +4,7 @@ import { GlobalAudioPlayer } from '../GlobalAudioPlayer';
 import { useAudioPlayer, useAudioPlayerSafe } from '@/contexts/AudioPlayerContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { AudioPlayerTrack } from '@/types/track';
+import { createRef } from 'react';
 
 // Mock the hooks
 vi.mock('@/contexts/AudioPlayerContext');
@@ -30,6 +31,7 @@ const defaultMockData = {
   volume: 0.7,
   queue: [],
   togglePlayPause: vi.fn(),
+  pauseTrack: vi.fn(),
   seekTo: vi.fn(),
   setVolume: vi.fn(),
   playNext: vi.fn(),
@@ -43,6 +45,11 @@ const defaultMockData = {
   clearCurrentTrack: vi.fn(),
   removeFromQueue: vi.fn(),
   playTrack: vi.fn(),
+  playTrackWithQueue: vi.fn(),
+  addToQueue: vi.fn(),
+  clearQueue: vi.fn(),
+  reorderQueue: vi.fn(),
+  audioRef: createRef<HTMLAudioElement>(),
   currentQueueIndex: 0,
 };
 
@@ -50,8 +57,8 @@ describe('GlobalAudioPlayer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default mock for both hooks
-    mockUseAudioPlayer.mockReturnValue(defaultMockData);
-    mockUseAudioPlayerSafe.mockReturnValue(defaultMockData);
+    mockUseAudioPlayer.mockReturnValue({ ...defaultMockData });
+    mockUseAudioPlayerSafe.mockReturnValue({ ...defaultMockData });
     mockUseIsMobile.mockReturnValue(false);
   });
 


### PR DESCRIPTION
## Summary
- extend the default audio player mock data to cover every field defined on the context, including queue helpers and the audio ref
- update the mocked hooks to return fresh copies of the default mock data in each test branch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e703504c10832fb2e4e2f0da3ca3d8