### PR TITLE
Refactor music generator form with new custom workflow

### DIFF
--- a/src/components/__tests__/MusicGenerator.smoke.test.tsx
+++ b/src/components/__tests__/MusicGenerator.smoke.test.tsx
@@ -1,28 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+
 import { MusicGenerator } from '../MusicGenerator';
 
 vi.mock('@/hooks/useMusicGeneration', () => ({
   useMusicGeneration: () => ({
-    prompt: 'Test prompt',
-    setPrompt: vi.fn(),
-    isGenerating: false,
-    isImproving: false,
-    provider: 'suno',
-    setProvider: vi.fn(),
-    hasVocals: false,
-    setHasVocals: vi.fn(),
-    lyrics: '',
-    setLyrics: vi.fn(),
-    styleTags: [],
-    setStyleTags: vi.fn(),
     generateMusic: vi.fn(),
     improvePrompt: vi.fn(),
+    isGenerating: false,
+    isImproving: false,
   }),
-}));
-
-vi.mock('@/hooks/useAudioPlayer', () => ({
-  useAudioPlayer: () => ({ currentTrack: null, isPlaying: false }),
 }));
 
 vi.mock('@/hooks/useHapticFeedback', () => ({
@@ -33,16 +20,21 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
-vi.mock('@/components/LyricsEditor', () => ({
-  LyricsEditor: () => <div data-testid="lyrics-editor">Lyrics editor</div>,
+vi.mock('@/hooks/useProviderBalance', () => ({
+  useProviderBalance: () => ({
+    balance: { balance: 3, currency: 'credits', provider: 'suno' },
+    isLoading: false,
+    error: null,
+  }),
 }));
 
 describe('MusicGenerator smoke test', () => {
-  it('renders core UI elements', () => {
+  it('renders core UI elements of redesigned form', () => {
     render(<MusicGenerator />);
 
-    expect(screen.getByText(/создайте свою музыку с ai/i)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/опишите желаемую музыку/i)).toBeInTheDocument();
-    expect(screen.getByTestId('lyrics-editor')).toBeInTheDocument();
+    expect(screen.getByText('Заголовок (опционально)')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Опишите желаемую музыку, настроение и ключевые инструменты')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Рандом' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Добавить лирику' })).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/MusicGenerator.test.tsx
+++ b/src/components/__tests__/MusicGenerator.test.tsx
@@ -48,40 +48,36 @@ describe('MusicGenerator component', () => {
     const user = userEvent.setup();
     render(<MusicGenerator />);
 
-    const createButton = screen.getByRole('button', { name: 'Create' });
+    const createButton = screen.getByRole('button', { name: 'Создать трек' });
     await user.click(createButton);
 
     expect(toastMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        description: 'Введите описание или выберите вдохновение',
+        description: 'Введите описание трека',
       }),
     );
   });
 
-  it('shows warning when vocals enabled without lyrics and proceeds after confirmation', async () => {
+  it('starts generation with filled prompt and resets the form', async () => {
     const user = userEvent.setup();
     const onTrackGenerated = vi.fn();
 
     render(<MusicGenerator onTrackGenerated={onTrackGenerated} />);
 
-    const textarea = screen.getByPlaceholderText('Hip-hop, R&B, upbeat');
+    const textarea = screen.getByPlaceholderText('Опишите желаемую музыку, настроение и ключевые инструменты');
     await user.type(textarea, 'Test melody');
 
-    const createButton = screen.getByRole('button', { name: 'Create' });
+    const createButton = screen.getByRole('button', { name: 'Создать трек' });
     await user.click(createButton);
 
-    expect(await screen.findByText('Confirm generation')).toBeInTheDocument();
-
-    const continueButton = screen.getByRole('button', { name: 'Continue' });
-    await user.click(continueButton);
-
-    await waitFor(() => expect(musicGenerationMocks.generateMusic).toHaveBeenCalled());
+    await waitFor(() => expect(musicGenerationMocks.generateMusic).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(onTrackGenerated).toHaveBeenCalled());
     await waitFor(() => expect(textarea).toHaveValue(''));
 
     expect(musicGenerationMocks.generateMusic).toHaveBeenCalledWith(
       expect.objectContaining({
         prompt: expect.stringContaining('Test melody'),
+        hasVocals: true,
       }),
     );
   });
@@ -90,10 +86,10 @@ describe('MusicGenerator component', () => {
     const user = userEvent.setup();
     render(<MusicGenerator />);
 
-    const textarea = screen.getByPlaceholderText('Hip-hop, R&B, upbeat');
+    const textarea = screen.getByPlaceholderText('Опишите желаемую музыку, настроение и ключевые инструменты');
     await user.type(textarea, 'Initial idea');
 
-    const enhanceButton = screen.getByRole('button', { name: 'Enhance' });
+    const enhanceButton = screen.getAllByRole('button', { name: 'Улучшить' })[0];
     await user.click(enhanceButton);
 
     expect(musicGenerationMocks.improvePrompt).toHaveBeenCalledWith('Initial idea');


### PR DESCRIPTION
## Summary
- redesign the music generator component with a simplified simple mode, collapsible custom blocks, and random prompt helpers
- add advanced controls for vocals, style exclusions, audio influence, and optional title support tied into generation params
- refresh the unit and smoke tests to exercise the new UI flows and validation logic

## Testing
- npx vitest run src/components/__tests__/MusicGenerator.test.tsx src/components/__tests__/MusicGenerator.alert.test.tsx src/components/__tests__/MusicGenerator.smoke.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e70e44b808832fadfd152e2395f145