### PR TITLE
Support wildcard origins in shared CORS helper

### DIFF
--- a/supabase/functions/_shared/cors_test.ts
+++ b/supabase/functions/_shared/cors_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, assertNotEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const importWithOrigins = async (origins: string) => {
+  if (origins) {
+    Deno.env.set("CORS_ALLOWED_ORIGINS", origins);
+  } else {
+    Deno.env.delete("CORS_ALLOWED_ORIGINS");
+  }
+
+  const module = await import(`./cors.ts?cachebust=${crypto.randomUUID()}`);
+  return module as typeof import("./cors.ts");
+};
+
+Deno.test("matches wildcard preview origins", async () => {
+  try {
+    const { createCorsHeaders } = await importWithOrigins("https://id-preview--*.lovable.app");
+
+    const headers = createCorsHeaders("https://id-preview--123.example.lovable.app");
+
+    assertEquals(headers["Access-Control-Allow-Origin"], "https://id-preview--123.example.lovable.app");
+    assertEquals(headers["Vary"], "Origin");
+  } finally {
+    Deno.env.delete("CORS_ALLOWED_ORIGINS");
+  }
+});
+
+Deno.test("rejects unrelated origins", async () => {
+  try {
+    const { createCorsHeaders } = await importWithOrigins("https://id-preview--*.lovable.app,https://lovable.app");
+
+    const headers = createCorsHeaders("https://malicious.example.com");
+
+    assertNotEquals(headers["Access-Control-Allow-Origin"], "https://malicious.example.com");
+    assertEquals(headers["Access-Control-Allow-Origin"], "https://id-preview--*.lovable.app");
+  } finally {
+    Deno.env.delete("CORS_ALLOWED_ORIGINS");
+  }
+});


### PR DESCRIPTION
## Summary
- expand the shared CORS helper to match wildcard origin patterns and echo the requesting origin when allowed
- add Deno tests covering preview-domain wildcard acceptance and unrelated origin rejection
- rebuild the project so updated helpers propagate to bundled assets

## Testing
- deno test supabase/functions/_shared/cors_test.ts *(fails: TLS certificate verification when downloading std asserts)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7399f26c0832f976dafdc2cbae3fc