### PR TITLE
Update CORS troubleshooting to include lovableproject preview domain

### DIFF
--- a/docs/TROUBLESHOOTING_TRACKS.md
+++ b/docs/TROUBLESHOOTING_TRACKS.md
@@ -184,8 +184,10 @@ Set current version index: 1
 ### Решение
 1. В Supabase → **Project Settings → API** добавьте/обновите секрет `CORS_ALLOWED_ORIGINS`:
    ```
-   https://lovable.dev,https://lovable.app,https://id-preview--*.lovable.app
+   https://lovable.dev,https://lovable.app,https://id-preview--*.lovable.app,https://*.lovableproject.com
    ```
+   > ⚠️ Новый превью-домен Lovable использует зону `lovableproject.com`. Без этого значения браузер блокирует CORS-префлайт, даже
+   > если другие домены уже перечислены.
    Секрет читается Edge-функциями во время старта, поэтому требуется деплой (`supabase functions deploy ...`).
 2. После деплоя убедитесь, что ответ содержит заголовки `Access-Control-Allow-Origin: https://id-preview--…` и `Access-Control-Allow-Credentials: true`.
 3. Для `get-balance` передавайте пользовательский токен Supabase (см. `createSupabaseUserClient`) — без него функция возвращает `401 Unauthorized`.


### PR DESCRIPTION
## Summary
- document the new lovableproject.com preview hostname in the CORS setup instructions
- note why adding the domain is required to unblock Supabase Edge Function calls from previews

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e73b4ac544832fbd4007b64662f432