### PR TITLE
Improve Suno balance fallback handling

### DIFF
--- a/docs/integrations/SUNO_API_AUDIT.md
+++ b/docs/integrations/SUNO_API_AUDIT.md
@@ -51,7 +51,7 @@
 - **Callback (`stems-callback`)**: совместим с новыми полями и не требует изменений.
 
 ### 2.4 Баланс провайдера
-- **Edge Function `get-balance`** остаётся без изменений; использует официальный `https://studio-api.suno.ai/api/billing/info/`.
+- **Edge Function `get-balance`** теперь опрашивает `https://studio-api.suno.ai/api/billing/info/` с резервным переходом на `https://api.sunoapi.org/api/v1/account/balance`, аккумулируя детали неуспешных попыток для диагностики.
 
 ---
 

--- a/supabase/functions/get-balance/index.ts
+++ b/supabase/functions/get-balance/index.ts
@@ -3,7 +3,248 @@ import { createCorsHeaders } from "../_shared/cors.ts";
 import { createSecurityHeaders } from "../_shared/security.ts";
 import { createSupabaseUserClient } from "../_shared/supabase.ts";
 
-const handler = async (req: Request): Promise<Response> => {
+type SunoBalanceAttempt = {
+  endpoint: string;
+  status?: number;
+  message: string;
+};
+
+const unique = (values: (string | undefined | null)[]): string[] => {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const normalised = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+    if (seen.has(normalised)) continue;
+    seen.add(normalised);
+    output.push(normalised);
+  }
+  return output;
+};
+
+const getSunoBalanceEndpoints = () => unique([
+  Deno.env.get("SUNO_BALANCE_URL"),
+  "https://studio-api.suno.ai/api/billing/info/",
+  "https://api.sunoapi.org/api/v1/account/balance",
+]);
+
+const extractNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const extractString = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+};
+
+const parseSunoBalance = (payload: unknown) => {
+  const containers: Record<string, unknown>[] = [];
+  if (payload && typeof payload === "object") {
+    containers.push(payload as Record<string, unknown>);
+
+    const data = (payload as Record<string, unknown>).data;
+    if (data && typeof data === "object") {
+      containers.push(data as Record<string, unknown>);
+    }
+
+    const balanceNode = (payload as Record<string, unknown>).balance;
+    if (balanceNode && typeof balanceNode === "object") {
+      containers.push(balanceNode as Record<string, unknown>);
+    }
+  }
+
+  let balance: number | null = null;
+  let currency: string | null = null;
+  let plan: string | null = null;
+
+  for (const container of containers) {
+    if (balance === null) {
+      const candidate = extractNumber(
+        container.balance ??
+          (container as Record<string, unknown>).balance_credits ??
+          (container as Record<string, unknown>).balanceCredits ??
+          (container as Record<string, unknown>).credits ??
+          (container as Record<string, unknown>).remaining_credits ??
+          (container as Record<string, unknown>).remainingCredits ??
+          (container as Record<string, unknown>).available_credits ??
+          (container as Record<string, unknown>).availableCredits ??
+          (container as Record<string, unknown>).credit_balance ??
+          (container as Record<string, unknown>).credits_remaining ??
+          (container as Record<string, unknown>).creditsRemaining ??
+          (container as Record<string, unknown>).usage_balance,
+      );
+      if (candidate !== null) {
+        balance = candidate;
+      }
+    }
+
+    if (currency === null) {
+      const candidate = extractString(
+        container.currency ??
+          (container as Record<string, unknown>).currency_code ??
+          (container as Record<string, unknown>).currencyCode ??
+          (container as Record<string, unknown>).plan_currency,
+      );
+      if (candidate) {
+        currency = candidate;
+      }
+    }
+
+    if (plan === null) {
+      const candidate = extractString(
+        container.plan ??
+          (container as Record<string, unknown>).plan_name ??
+          (container as Record<string, unknown>).planName ??
+          (container as Record<string, unknown>).subscription ??
+          (container as Record<string, unknown>).tier ??
+          (container as Record<string, unknown>).plan_display_name,
+      );
+      if (candidate) {
+        plan = candidate;
+      }
+    }
+
+    if (balance !== null && currency && plan) {
+      break;
+    }
+  }
+
+  return { balance, currency, plan };
+};
+
+const fetchSunoBalanceFromEndpoint = async (
+  endpoint: string,
+  apiKey: string,
+): Promise<{
+  balance: number | null;
+  currency: string | null;
+  plan: string | null;
+}> => {
+  const response = await fetch(endpoint, {
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Accept": "application/json",
+    },
+  });
+
+  const rawText = await response.text();
+  let json: unknown = null;
+  if (rawText) {
+    try {
+      json = JSON.parse(rawText);
+    } catch (parseError) {
+      throw Object.assign(new Error("Invalid JSON response from Suno balance endpoint"), {
+        status: response.status,
+        body: rawText,
+        cause: parseError,
+      });
+    }
+  }
+
+  if (!response.ok) {
+    const error = new Error(`Suno balance endpoint responded with status ${response.status}`);
+    (error as Error & { status?: number; body?: string }).status = response.status;
+    (error as Error & { status?: number; body?: string }).body = rawText;
+    throw error;
+  }
+
+  const parsed = parseSunoBalance(json);
+  if (parsed.balance === null) {
+    const error = new Error("Suno balance response did not contain a numeric balance value");
+    (error as Error & { status?: number; body?: string }).status = response.status;
+    (error as Error & { status?: number; body?: string }).body = rawText;
+    throw error;
+  }
+
+  return parsed;
+};
+
+export const getSunoBalance = async () => {
+  const SUNO_API_KEY = Deno.env.get("SUNO_API_KEY");
+  if (!SUNO_API_KEY) {
+    return { provider: "suno", balance: 0, error: "API key not configured" };
+  }
+
+  const attempts: SunoBalanceAttempt[] = [];
+  const endpoints = getSunoBalanceEndpoints();
+
+  for (const endpoint of endpoints) {
+    if (!endpoint) continue;
+    try {
+      const { balance, currency, plan } = await fetchSunoBalanceFromEndpoint(endpoint, SUNO_API_KEY);
+      return {
+        provider: "suno",
+        balance: balance ?? 0,
+        currency: currency ?? "credits",
+        plan: plan ?? "unknown",
+        endpoint,
+      };
+    } catch (error) {
+      const status = (error as Error & { status?: number }).status;
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === "string"
+            ? error
+            : "Unknown error";
+      console.error("Suno balance endpoint failed", { endpoint, status, message });
+      attempts.push({ endpoint, status, message });
+    }
+  }
+
+  if (!attempts.length) {
+    return { provider: "suno", balance: 0, error: "No Suno balance endpoints configured" };
+  }
+
+  return {
+    provider: "suno",
+    balance: 0,
+    error: "All Suno balance endpoints failed",
+    attempts,
+  };
+};
+
+export const getReplicateBalance = async () => {
+  const REPLICATE_API_KEY = Deno.env.get("REPLICATE_API_KEY");
+  if (!REPLICATE_API_KEY) {
+    return { provider: "replicate", balance: 0, error: "API key not configured" };
+  }
+
+  const response = await fetch("https://api.replicate.com/v1/account", {
+    method: "GET",
+    headers: { "Authorization": `Token ${REPLICATE_API_KEY}` },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Replicate API error:", response.status, errorText);
+    return { provider: "replicate", balance: 0, error: `Replicate API error: ${response.status}` };
+  }
+
+  const data = await response.json();
+  return {
+    provider: "replicate",
+    balance: 999,
+    currency: "credits",
+    plan: data.type || "unknown",
+    message: "Balance cannot be fetched via API. Please check your Replicate dashboard.",
+  };
+};
+
+export const handler = async (req: Request): Promise<Response> => {
   const corsHeaders = createCorsHeaders(req);
   const securityHeaders = createSecurityHeaders();
 
@@ -12,7 +253,6 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   try {
-    // 1. Authenticate user
     const authHeader = req.headers.get('Authorization');
     if (!authHeader) {
       return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
@@ -42,11 +282,9 @@ const handler = async (req: Request): Promise<Response> => {
       });
     }
 
-    // 2. Get provider from query params or request body
     const url = new URL(req.url);
     let provider = url.searchParams.get('provider');
 
-    // If not in query params and method is POST, try reading from body
     if (!provider && req.method === 'POST') {
       try {
         const body = await req.json();
@@ -65,7 +303,6 @@ const handler = async (req: Request): Promise<Response> => {
 
     let balanceResponse;
 
-    // 3. Fetch balance based on provider
     if (provider === 'suno') {
       balanceResponse = await getSunoBalance();
     } else if (provider === 'replicate') {
@@ -87,73 +324,6 @@ const handler = async (req: Request): Promise<Response> => {
   }
 };
 
-const getSunoBalance = async () => {
-  const SUNO_API_KEY = Deno.env.get('SUNO_API_KEY');
-  if (!SUNO_API_KEY) {
-    return { provider: 'suno', balance: 0, error: 'API key not configured' };
-  }
-
-  // Используем SunoAPI.org вместо официального API
-  const response = await fetch('https://api.sunoapi.org/api/v1/account/balance', {
-    method: 'GET',
-    headers: { 'Authorization': `Bearer ${SUNO_API_KEY}` },
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Suno API error:', response.status, errorText);
-    // Return a soft error, so the frontend can try the next provider
-    return { provider: 'suno', balance: 0, error: `Suno API error: ${response.status}`, details: errorText };
-  }
-
-  const data = await response.json();
-  // SunoAPI.org возвращает данные в формате { code, msg, data: { balance, currency } }
-  if (data.code === 200 && data.data) {
-    return {
-      provider: 'suno',
-      balance: data.data.balance || 0,
-      currency: data.data.currency || 'credits',
-      plan: data.data.plan || 'unknown',
-    };
-  } else {
-    return {
-      provider: 'suno',
-      balance: 0,
-      error: data.msg || 'Unknown error',
-      currency: 'credits',
-    };
-  }
-};
-
-const getReplicateBalance = async () => {
-  const REPLICATE_API_KEY = Deno.env.get('REPLICATE_API_KEY');
-  if (!REPLICATE_API_KEY) {
-    return { provider: 'replicate', balance: 0, error: 'API key not configured' };
-  }
-
-  const response = await fetch('https://api.replicate.com/v1/account', {
-    method: 'GET',
-    headers: { 'Authorization': `Token ${REPLICATE_API_KEY}` },
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Replicate API error:', response.status, errorText);
-    return { provider: 'replicate', balance: 0, error: `Replicate API error: ${response.status}` };
-  }
-
-  const data = await response.json();
-  // NOTE: Replicate does not provide a direct balance API endpoint.
-  // We are returning a placeholder value. The actual credit usage is tracked on their website.
-  // For the purpose of this feature, we will return a static, non-zero value
-  // to indicate the service is active, and the real balance should be checked on the Replicate website.
-  return {
-    provider: 'replicate',
-    balance: 999, // Placeholder value
-    currency: 'credits',
-    plan: data.type || 'unknown',
-    message: 'Balance cannot be fetched via API. Please check your Replicate dashboard.',
-  };
-};
-
-serve(handler);
+if (import.meta.main) {
+  serve(handler);
+}

--- a/supabase/functions/tests/get-balance.test.ts
+++ b/supabase/functions/tests/get-balance.test.ts
@@ -1,0 +1,125 @@
+import { assert, assertEquals, assertMatch } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { getSunoBalance } from "../get-balance/index.ts";
+
+const realFetch = globalThis.fetch;
+
+const resolveUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+};
+
+Deno.test({
+  name: "returns balance from primary studio endpoint when available",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    Deno.env.set("SUNO_API_KEY", "test-key");
+    Deno.env.delete("SUNO_BALANCE_URL");
+
+    const calls: string[] = [];
+    globalThis.fetch = async (input, _init) => {
+      const url = resolveUrl(input);
+      calls.push(url);
+      return new Response(
+        JSON.stringify({
+          data: {
+            balance: 42,
+            currency: "credits",
+            plan: "studio",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    };
+
+    try {
+      const result = await getSunoBalance();
+      assertEquals(result.balance, 42);
+      assertEquals(result.currency, "credits");
+      assertEquals(result.plan, "studio");
+      assert(result.endpoint?.includes("studio-api.suno.ai"));
+      assertEquals(calls.length, 1);
+      assertMatch(calls[0], /https:\/\/studio-api\.suno\.ai\/api\/billing\/info/);
+    } finally {
+      globalThis.fetch = realFetch;
+      Deno.env.delete("SUNO_API_KEY");
+    }
+  },
+});
+
+Deno.test({
+  name: "falls back to sunoapi endpoint when studio endpoint fails",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    Deno.env.set("SUNO_API_KEY", "test-key");
+    Deno.env.delete("SUNO_BALANCE_URL");
+
+    const calls: string[] = [];
+    globalThis.fetch = async (input, _init) => {
+      const url = resolveUrl(input);
+      calls.push(url);
+      if (url.includes("studio-api.suno.ai")) {
+        return new Response("upstream error", { status: 502 });
+      }
+      return new Response(
+        JSON.stringify({ code: 200, data: { balance: 13, currency: "credits", plan: "plus" } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    };
+
+    try {
+      const result = await getSunoBalance();
+      assertEquals(result.balance, 13);
+      assertEquals(result.currency, "credits");
+      assertEquals(result.plan, "plus");
+      assert(result.endpoint?.includes("api.sunoapi.org"));
+      assertEquals(calls.length, 2);
+    } finally {
+      globalThis.fetch = realFetch;
+      Deno.env.delete("SUNO_API_KEY");
+    }
+  },
+});
+
+Deno.test({
+  name: "returns aggregated error when all endpoints fail",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    Deno.env.set("SUNO_API_KEY", "test-key");
+    Deno.env.delete("SUNO_BALANCE_URL");
+
+    globalThis.fetch = async () => new Response("nope", { status: 500 });
+
+    try {
+      const result = await getSunoBalance();
+      assertEquals(result.balance, 0);
+      assertEquals(result.error, "All Suno balance endpoints failed");
+      assert(Array.isArray(result.attempts));
+      assert(result.attempts!.length >= 2);
+    } finally {
+      globalThis.fetch = realFetch;
+      Deno.env.delete("SUNO_API_KEY");
+    }
+  },
+});
+
+Deno.test({
+  name: "returns configuration error when api key missing",
+  async fn() {
+    Deno.env.delete("SUNO_API_KEY");
+    globalThis.fetch = realFetch;
+
+    const result = await getSunoBalance();
+    assertEquals(result.balance, 0);
+    assertEquals(result.error, "API key not configured");
+  },
+});


### PR DESCRIPTION
## Summary
- add a resilient balance fetcher that prefers the official studio billing endpoint and falls back to sunoapi.org with diagnostic logging
- expose the balance helper for reuse, add targeted tests, and document the new fallback strategy

## Testing
- deno test supabase/functions/tests/get-balance.test.ts *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7442478a8832f9e691ced63977764