### PR TITLE
Adjust CORS credentials for wildcard origins

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -72,11 +72,11 @@ export const createCorsHeaders = (requestOrOrigin?: Request | string | null) => 
     'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-app-environment',
     'Access-Control-Max-Age': '86400',
-    'Access-Control-Allow-Credentials': 'true',
   };
 
   if (allowOrigin !== '*') {
     headers['Vary'] = 'Origin';
+    headers['Access-Control-Allow-Credentials'] = 'true';
   }
 
   return headers;

--- a/supabase/functions/_shared/cors_test.ts
+++ b/supabase/functions/_shared/cors_test.ts
@@ -36,3 +36,16 @@ Deno.test("rejects unrelated origins", async () => {
     Deno.env.delete("CORS_ALLOWED_ORIGINS");
   }
 });
+
+Deno.test("omits credentials header when default wildcard origin is used", async () => {
+  try {
+    const { createCorsHeaders } = await importWithOrigins("");
+
+    const headers = createCorsHeaders();
+
+    assertEquals(headers["Access-Control-Allow-Origin"], "*");
+    assertEquals(headers["Access-Control-Allow-Credentials"], undefined);
+  } finally {
+    Deno.env.delete("CORS_ALLOWED_ORIGINS");
+  }
+});


### PR DESCRIPTION
## Summary
- ensure CORS helper only sets Access-Control-Allow-Credentials when echoing a concrete origin
- add regression test confirming the wildcard default omits the credentials header

## Testing
- DENO_TLS_CA_STORE=system ~/.deno/bin/deno test --allow-env --allow-read --allow-net=deno.land supabase/functions/_shared/cors_test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e749b019d4832fb9b5b506e6708834