### PR TITLE
Improve CORS subdomain handling for Lovable preview domains

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -26,6 +26,24 @@ const wildcardToRegExp = (pattern: string): RegExp => {
   return new RegExp(`^${escaped}$`);
 };
 
+const isSubdomainMatch = (requestedOrigin: string, allowedOrigin: string): boolean => {
+  try {
+    const requestedUrl = new URL(requestedOrigin);
+    const allowedUrl = new URL(allowedOrigin);
+
+    if (requestedUrl.protocol !== allowedUrl.protocol) {
+      return false;
+    }
+
+    const requestedHost = requestedUrl.hostname;
+    const allowedHost = allowedUrl.hostname;
+
+    return requestedHost === allowedHost || requestedHost.endsWith(`.${allowedHost}`);
+  } catch {
+    return false;
+  }
+};
+
 const resolveAllowedOrigin = (requestOrOrigin?: Request | string | null): string => {
   const requestedOrigin = typeof requestOrOrigin === 'string'
     ? requestOrOrigin
@@ -46,6 +64,10 @@ const resolveAllowedOrigin = (requestOrOrigin?: Request | string | null): string
         if (regex.test(requestedOrigin)) {
           return requestedOrigin;
         }
+      }
+
+      if (isSubdomainMatch(requestedOrigin, origin)) {
+        return requestedOrigin;
       }
     }
   }


### PR DESCRIPTION
## Summary
- allow the shared CORS helper to treat configured origins as valid for their subdomains
- ensure preview environments on lovable.app and lovableproject.com can pass browser preflight checks without extra configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74b087b40832fa2e80c5ff569a4b5