### PR TITLE
Add cached track fallback for getUserTracks

### DIFF
--- a/src/services/__tests__/api.service.test.ts
+++ b/src/services/__tests__/api.service.test.ts
@@ -1,12 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.fn();
+const fromMock = vi.fn();
 
 vi.mock("@/integrations/supabase/client", () => ({
   supabase: {
     functions: {
       invoke: invokeMock,
     },
+    from: fromMock,
   },
 }));
 
@@ -17,7 +19,27 @@ vi.mock("@/utils/logger", () => ({
   logWarn: vi.fn(),
 }));
 
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+vi.stubGlobal("localStorage", localStorageMock as unknown as Storage);
+
 const { ApiService } = await vi.importActual<typeof import("../api.service")>("../api.service");
+const { trackCache } = await vi.importActual<typeof import("@/utils/trackCache")>("@/utils/trackCache");
 
 describe("ApiService.generateMusic", () => {
   beforeEach(() => {
@@ -50,5 +72,71 @@ describe("ApiService.generateMusic", () => {
     expect(payload.lyrics).toBe(request.lyrics);
     expect(payload.hasVocals).toBe(true);
     expect(payload.customMode).toBe(true);
+  });
+});
+
+describe("ApiService.getUserTracks", () => {
+  const createErroredQuery = () => {
+    const response = Promise.resolve({
+      data: null,
+      error: {
+        message: "Supabase unavailable",
+        details: "network error",
+        hint: null,
+        code: "500",
+      },
+    });
+
+    const chain: Record<string, unknown> = {};
+
+    Object.assign(chain, {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      order: vi.fn(() => response),
+    });
+
+    return chain;
+  };
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    fromMock.mockReset();
+    localStorageMock.clear();
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.removeItem.mockClear();
+    localStorageMock.clear.mockClear();
+  });
+
+  afterEach(() => {
+    trackCache.clearCache();
+  });
+
+  it("falls back to cached tracks when Supabase fails", async () => {
+    const userId = "user-123";
+    const cachedTrack = {
+      id: "track-1",
+      title: "Cached Track",
+      artist: "Offline Artist",
+      audio_url: "https://example.com/audio.mp3",
+      image_url: "https://example.com/cover.jpg",
+      duration: 180,
+      genre: "synthwave",
+      created_at: new Date().toISOString(),
+    } as const;
+
+    trackCache.setTrack(cachedTrack);
+
+    fromMock.mockReturnValue(createErroredQuery());
+
+    const result = await ApiService.getUserTracks(userId);
+
+    expect(fromMock).toHaveBeenCalledWith("tracks");
+    expect(result).toHaveLength(1);
+    const [track] = result;
+    expect(track.id).toBe(cachedTrack.id);
+    expect(track.audio_url).toBe(cachedTrack.audio_url);
+    expect(track.status).toBe("completed");
+    expect(track.user_id).toBe(userId);
   });
 });


### PR DESCRIPTION
## Summary
- add a TrackCacheManager helper for returning non-expired cached tracks
- map cached records to Track objects when Supabase fetches fail
- cover the cached fallback flow with a unit test for getUserTracks

## Testing
- npx vitest run src/services/__tests__/api.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e76da77cdc832fb7d4ef52926c2859