### PR TITLE
Track view analytics with session guard

### DIFF
--- a/src/components/workspace/__tests__/DetailPanelContent.analytics.test.tsx
+++ b/src/components/workspace/__tests__/DetailPanelContent.analytics.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DetailPanelContent } from '../DetailPanelContent';
+import { supabase } from '@/integrations/supabase/client';
+import { viewSessionGuard } from '@/services/analytics.service';
+
+vi.mock('@/hooks/useTrackLike', () => ({
+  useTrackLike: () => ({
+    isLiked: false,
+    likeCount: 0,
+    toggleLike: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/tracks/TrackVersions', () => ({
+  TrackVersions: () => null,
+}));
+
+vi.mock('@/components/tracks/TrackStemsPanel', () => ({
+  TrackStemsPanel: () => null,
+}));
+
+vi.mock('@/components/workspace/StyleRecommendationsPanel', () => ({
+  StyleRecommendationsPanel: () => null,
+}));
+
+describe('DetailPanelContent analytics integration', () => {
+  const baseTrack = {
+    id: 'track-123',
+    title: 'Test track',
+    prompt: 'A calm piano piece',
+    status: 'completed' as const,
+    audio_url: 'https://example.com/audio.mp3',
+    created_at: new Date().toISOString(),
+    like_count: 0,
+    view_count: 0,
+  };
+
+  const defaultProps = {
+    track: baseTrack,
+    title: baseTrack.title,
+    setTitle: vi.fn(),
+    genre: '',
+    setGenre: vi.fn(),
+    mood: '',
+    setMood: vi.fn(),
+    isPublic: true,
+    setIsPublic: vi.fn(),
+    isSaving: false,
+    versions: [],
+    stems: [],
+    onSave: vi.fn(),
+    onDownload: vi.fn(),
+    onShare: vi.fn(),
+    onDelete: vi.fn(),
+    loadVersionsAndStems: vi.fn(),
+  };
+
+  let rpcSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    viewSessionGuard.clear();
+    try {
+      globalThis.sessionStorage?.clear();
+    } catch (error) {
+      // ignore session storage issues in tests
+    }
+    rpcSpy = vi.spyOn(supabase, 'rpc').mockResolvedValue({ data: null, error: null } as any);
+  });
+
+  afterEach(() => {
+    rpcSpy.mockRestore();
+  });
+
+  it('records view and play counters when the detail panel mounts', async () => {
+    render(<DetailPanelContent {...defaultProps} />);
+
+    await waitFor(() => expect(rpcSpy).toHaveBeenCalledTimes(2));
+    expect(rpcSpy).toHaveBeenCalledWith('increment_view_count', { track_id: baseTrack.id });
+    expect(rpcSpy).toHaveBeenCalledWith('increment_play_count', { track_id: baseTrack.id });
+  });
+
+  it('avoids duplicate counter calls during the same session', async () => {
+    const { unmount } = render(<DetailPanelContent {...defaultProps} />);
+    await waitFor(() => expect(rpcSpy).toHaveBeenCalledTimes(2));
+
+    rpcSpy.mockClear();
+    unmount();
+    render(
+      <DetailPanelContent
+        {...defaultProps}
+        track={{ ...baseTrack }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(rpcSpy).not.toHaveBeenCalled();
+    }, { timeout: 200 });
+  });
+});

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { useNavigate } from "react-router-dom";
 import { Music, Sparkles, Zap, Headphones, Wand2, Play, Heart } from "lucide-react";
 import { ApiService, Track } from "@/services/api.service";
+import { AnalyticsService } from "@/services/analytics.service";
 import { useAudioPlayerSafe } from "@/contexts/AudioPlayerContext";
 import heroBg from "@/assets/hero-bg.jpg";
 
@@ -24,6 +25,20 @@ const Landing = () => {
     };
     fetchFeaturedTracks();
   }, []);
+
+  useEffect(() => {
+    if (!featuredTracks.length) {
+      return;
+    }
+
+    featuredTracks.forEach((track) => {
+      if (track.id) {
+        AnalyticsService.recordView(track.id).catch((error) => {
+          console.error('Failed to record landing track view', error);
+        });
+      }
+    });
+  }, [featuredTracks]);
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/pages/workspace/Analytics.tsx
+++ b/src/pages/workspace/Analytics.tsx
@@ -139,7 +139,10 @@ const Analytics = () => {
             <Eye className="h-4 w-4 text-blue-500" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gradient-primary">
+            <div
+              data-testid="analytics-total-views"
+              className="text-2xl font-bold text-gradient-primary"
+            >
               {overallStats?.totalViews || 0}
             </div>
           </CardContent>
@@ -151,7 +154,10 @@ const Analytics = () => {
             <TrendingUp className="h-4 w-4 text-green-500" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gradient-primary">
+            <div
+              data-testid="analytics-total-plays"
+              className="text-2xl font-bold text-gradient-primary"
+            >
               {overallStats?.totalPlays || 0}
             </div>
           </CardContent>

--- a/src/pages/workspace/Dashboard.tsx
+++ b/src/pages/workspace/Dashboard.tsx
@@ -7,6 +7,7 @@ import { TrackCard } from "@/components/TrackCard";
 import { useToast } from "@/hooks/use-toast";
 import { normalizeTracks } from "@/utils/trackNormalizer";
 import { useDashboardData, DEFAULT_DASHBOARD_STATS } from "@/hooks/useDashboardData";
+import { AnalyticsService } from "@/services/analytics.service";
 
 const Dashboard = () => {
   const navigate = useNavigate();
@@ -14,6 +15,20 @@ const Dashboard = () => {
   const { data, isLoading, error } = useDashboardData();
   const stats = data?.stats ?? DEFAULT_DASHBOARD_STATS;
   const publicTracks = useMemo(() => normalizeTracks(data?.publicTracks ?? []), [data?.publicTracks]);
+
+  useEffect(() => {
+    if (!publicTracks.length) {
+      return;
+    }
+
+    publicTracks.forEach((track) => {
+      if (track.id) {
+        AnalyticsService.recordView(track.id).catch((error) => {
+          console.error('Failed to record dashboard track view', error);
+        });
+      }
+    });
+  }, [publicTracks]);
 
   useEffect(() => {
     if (!error) {

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { loginToApp } from './utils';
+
+const extractCount = async (locator: import('@playwright/test').Locator) => {
+  const text = (await locator.innerText()).trim();
+  const numeric = text.replace(/[^\d]/g, '');
+  return Number(numeric || '0');
+};
+
+test.describe('Analytics counters', () => {
+  test('increment after viewing a track detail panel', async ({ page }) => {
+    await loginToApp(page);
+
+    await page.goto('/workspace/analytics');
+    await page.waitForSelector('[data-testid="analytics-total-views"]');
+
+    const viewsLocator = page.getByTestId('analytics-total-views');
+    const playsLocator = page.getByTestId('analytics-total-plays');
+
+    const initialViews = await extractCount(viewsLocator);
+    const initialPlays = await extractCount(playsLocator);
+
+    await page.goto('/workspace/generate');
+
+    const firstTrackCard = page.locator('[aria-label^="Трек"]').first();
+    await expect(firstTrackCard).toBeVisible();
+    await firstTrackCard.click();
+
+    await expect(page.getByRole('button', { name: 'Статистика' })).toBeVisible();
+    await page.waitForTimeout(500);
+
+    await page.goto('/workspace/analytics');
+    await page.waitForSelector('[data-testid="analytics-total-views"]');
+
+    await expect
+      .poll(async () => extractCount(page.getByTestId('analytics-total-views')), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(initialViews);
+
+    await expect
+      .poll(async () => extractCount(page.getByTestId('analytics-total-plays')), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(initialPlays);
+  });
+});


### PR DESCRIPTION
## Summary
- add a session-aware view guard and recordView helper to the analytics service while updating aggregates
- trigger view recording on landing, dashboard, and track detail panels alongside refreshed analytics copy
- extend coverage with a vitest detail panel suite and a Playwright smoke test that exercises counter updates

## Testing
- `npx vitest run src/components/workspace/__tests__/DetailPanelContent.analytics.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68e77846096c832fa653b904674d2655