### PR TITLE
Point library track version imports to feature API

### DIFF
--- a/archive/2025/october/sprint-20-completed.md
+++ b/archive/2025/october/sprint-20-completed.md
@@ -393,7 +393,7 @@ docs/TROUBLESHOOTING_TRACKS.md:
 - `src/components/player/FullScreenPlayer.tsx` - Mobile UI
 - `src/hooks/useTrackVersions.ts` - Hook для версий
 - `src/components/tracks/TrackVersionBadge.tsx` - UI компонент
-- `src/utils/trackVersions.ts` - Утилиты версий
+- `src/features/tracks/api/trackVersions.ts` - Утилиты версий
 - `supabase/functions/generate-suno/index.ts` - Сохранение версий
 
 ---

--- a/project-management/NAVIGATION_INDEX.md
+++ b/project-management/NAVIGATION_INDEX.md
@@ -146,7 +146,7 @@ archive/
 ### База данных
 - [Database Schema](../supabase/migrations/)
 - [RLS Policies](../docs/architecture/ARCHITECTURE.md)
-- [Track Versions](../src/utils/trackVersions.ts)
+- [Track Versions](../src/features/tracks/api/trackVersions.ts)
 
 ### Тестирование
 - [Test Setup](../src/test/setup.ts)

--- a/src/pages/workspace/Library.tsx
+++ b/src/pages/workspace/Library.tsx
@@ -26,7 +26,7 @@ import { DisplayTrack, convertToAudioPlayerTrack, convertToDisplayTrack, convert
 import { cn } from "@/lib/utils";
 import { logger } from "@/utils/logger";
 import { normalizeTrack } from "@/utils/trackNormalizer";
-import { getTrackWithVersions, type TrackWithVersions } from "@/utils/trackVersions";
+import { getTrackWithVersions, type TrackWithVersions } from "@/features/tracks/api/trackVersions";
 import type { AudioPlayerTrack } from "@/types/track";
 
 type ViewMode = 'grid' | 'list' | 'optimized';


### PR DESCRIPTION
## Summary
- update the workspace library page to import track version helpers directly from the feature API module
- remove the redundant `src/utils/trackVersions.ts` re-export and refresh documentation links to point at the canonical file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e78114fff0832f9ad4c59c9140dad2