### PR TITLE
Improve tag palette dialog accessibility

### DIFF
--- a/src/components/lyrics/SectionCard.tsx
+++ b/src/components/lyrics/SectionCard.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -209,7 +210,13 @@ export const SectionCard: React.FC<SectionCardProps> = ({
       <Dialog open={showTagPalette} onOpenChange={setShowTagPalette}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>Add Tags to {section.title}</DialogTitle>
+            <DialogTitle>
+              Add Tags to {section.title?.trim() ? section.title : 'section'}
+            </DialogTitle>
+            <DialogDescription>
+              Choose tags to annotate this section. Selected tags will be added
+              immediately.
+            </DialogDescription>
           </DialogHeader>
           <TagPalette
             onAddTag={(tag) => {


### PR DESCRIPTION
## Summary
- add a dialog description to the tag palette modal so it no longer mounts without accessible labelling
- ensure the dialog title falls back to a generic section label when the section has no name

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e79d7dcfb4832f8600422b6d7b12f6