### PR TITLE
Improve mobile viewport and touch comfort

### DIFF
--- a/src/components/workspace/NotificationsDropdown.tsx
+++ b/src/components/workspace/NotificationsDropdown.tsx
@@ -69,7 +69,7 @@ export const NotificationsDropdown = () => {
         <Button
           variant="ghost"
           size="sm"
-          className="relative w-10 h-10 p-0 hover:bg-accent/10 rounded-xl transition-all duration-300 hover:scale-105"
+          className="relative w-11 h-11 sm:w-10 sm:h-10 p-0 hover:bg-accent/10 rounded-xl transition-all duration-300 hover:scale-105"
         >
           <Bell className="w-5 h-5" />
           {unreadCount > 0 && (

--- a/src/components/workspace/UserProfileDropdown.tsx
+++ b/src/components/workspace/UserProfileDropdown.tsx
@@ -52,9 +52,9 @@ export const UserProfileDropdown = ({ userEmail }: UserProfileDropdownProps) => 
         <Button
           variant="ghost"
           size="sm"
-          className="w-10 h-10 p-0 rounded-full hover:scale-105 transition-all duration-300"
+          className="w-11 h-11 sm:w-10 sm:h-10 p-0 rounded-full hover:scale-105 transition-all duration-300"
         >
-          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 backdrop-blur-xl border border-primary/20 flex items-center justify-center hover:border-primary/40 transition-all duration-300">
+          <div className="w-11 h-11 sm:w-10 sm:h-10 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 backdrop-blur-xl border border-primary/20 flex items-center justify-center hover:border-primary/40 transition-all duration-300">
             <User className="h-5 w-5 text-primary" />
           </div>
         </Button>

--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -53,7 +53,7 @@ const WorkspaceHeader = ({ className }: WorkspaceHeaderProps) => {
         <Button
           variant="ghost"
           size="sm"
-          className="sm:hidden w-10 h-10 p-0 hover:bg-accent/10 rounded-xl transition-all duration-300"
+          className="sm:hidden w-11 h-11 p-0 hover:bg-accent/10 rounded-xl transition-all duration-300"
         >
           <Search className="w-5 h-5" />
         </Button>

--- a/src/components/workspace/WorkspaceLayout.tsx
+++ b/src/components/workspace/WorkspaceLayout.tsx
@@ -9,7 +9,7 @@ const WorkspaceLayout = () => {
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false);
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className="flex min-h-screen min-h-[100dvh] bg-background">
       {/* Sidebar - Desktop only */}
       <MinimalSidebar
         isExpanded={isSidebarExpanded}
@@ -18,13 +18,17 @@ const WorkspaceLayout = () => {
       />
 
       {/* Main Content */}
-      <div className={cn(
-        "flex-1 flex flex-col min-w-0 transition-all duration-300",
-        isSidebarExpanded ? "ml-0 lg:ml-64" : "ml-0 lg:ml-16"
-      )}>
+      <div
+        className={cn(
+          "flex-1 flex flex-col min-w-0 min-h-[100dvh] transition-all duration-300",
+          isSidebarExpanded ? "ml-0 lg:ml-64" : "ml-0 lg:ml-16"
+        )}
+      >
         <WorkspaceHeader className="safe-area-inset lg:block hidden" />
-        
-        <main className="flex-1 overflow-y-auto pb-[72px] lg:pb-0 bg-gradient-to-br from-background via-background to-accent/5 scrollbar-styled">
+
+        <main
+          className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-[72px] supports-[padding:env(safe-area-inset-bottom)]:pb-[calc(72px+env(safe-area-inset-bottom))] lg:pb-0 bg-gradient-to-br from-background via-background to-accent/5 scrollbar-styled"
+        >
           <Outlet />
         </main>
 

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -41,9 +41,9 @@ const Landing = () => {
   }, [featuredTracks]);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen min-h-[100dvh] bg-background">
       {/* Hero Section */}
-      <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
+      <section className="relative min-h-screen min-h-[100dvh] flex items-center justify-center overflow-hidden">
         {/* Background Image with Overlay */}
         <div className="absolute inset-0">
           <img 
@@ -66,11 +66,11 @@ const Landing = () => {
             </div>
           </div>
           
-          <h1 className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black mb-6 text-gradient-primary animate-slide-up leading-tight">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-black mb-6 text-gradient-primary animate-slide-up leading-tight">
             MusicAI Pro
           </h1>
-          
-          <p className="text-xl md:text-2xl text-foreground/80 max-w-3xl mx-auto mb-4 animate-fade-in font-medium" style={{ animationDelay: '0.2s' }}>
+
+          <p className="text-lg sm:text-xl md:text-2xl text-foreground/80 max-w-3xl mx-auto mb-4 animate-fade-in font-medium" style={{ animationDelay: '0.2s' }}>
             Создавайте профессиональную музыку с помощью AI за минуты
           </p>
           
@@ -128,7 +128,7 @@ const Landing = () => {
             </p>
           </div>
           
-          <div className="grid md:grid-cols-3 gap-6 lg:gap-8 max-w-6xl mx-auto">
+          <div className="grid md:grid-cols-3 gap-6 lg:gap-8 gap-y-10 max-w-6xl mx-auto">
             <div className="group p-8 rounded-3xl border-2 border-border/50 bg-gradient-to-br from-card/90 to-card/40 backdrop-blur-xl hover:border-primary/50 hover-lift transition-all duration-300 hover:shadow-glow-primary animate-scale-in">
               <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-primary/30 to-primary/10 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform glow-primary">
                 <Zap className="w-8 h-8 text-primary" />
@@ -177,7 +177,7 @@ const Landing = () => {
               </p>
             </div>
 
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto mb-12">
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 gap-y-8 max-w-6xl mx-auto mb-12">
               {featuredTracks.map((track, index) => (
                 <Card 
                   key={track.id} 


### PR DESCRIPTION
## Summary
- adopt dynamic viewport units and safe-area aware padding in the workspace shell to avoid clipping on mobile browsers
- enlarge key header touch targets and adjust landing hero typography and spacing for smaller screens

## Testing
- npm run lint *(fails: existing repository lint violations)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e7c208be74832fb61491b5762a4bb7