### PR TITLE
Enhance track detail panel layout and version handling

### DIFF
--- a/src/components/workspace/DetailPanelContent.tsx
+++ b/src/components/workspace/DetailPanelContent.tsx
@@ -1,16 +1,17 @@
-// import { useState } from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Download, Share2, Trash2, Eye, Heart, Calendar, Clock, ExternalLink, Play } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-// import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrackVersions, TrackStemsPanel, useTrackLike } from "@/features/tracks";
+import { TrackDetailsPanel } from "@/features/tracks/ui/TrackDetailsPanel";
+import { TrackVersionSelector } from "@/features/tracks/ui/TrackVersionSelector";
 import { cn } from "@/lib/utils";
 import { StyleRecommendationsPanel } from "./StyleRecommendationsPanel";
 import type { StylePreset } from "@/types/styles";
@@ -52,6 +53,7 @@ interface TrackVersion {
   lyrics?: string;
   duration?: number;
   metadata?: Record<string, unknown>;
+  created_at?: string;
 }
 
 interface TrackStem {
@@ -59,6 +61,8 @@ interface TrackStem {
   stem_type: string;
   audio_url: string;
   separation_mode: string;
+  version_id?: string | null;
+  created_at?: string;
 }
 
 interface DetailPanelContentProps {
@@ -81,18 +85,24 @@ interface DetailPanelContentProps {
   loadVersionsAndStems: () => void;
 }
 
-const formatDate = (date: string) => {
-  return new Date(date).toLocaleDateString("ru-RU", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
+const formatDate = (date?: string) => {
+  if (!date) return "—";
+  try {
+    return new Date(date).toLocaleDateString("ru-RU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return "—";
+  }
 };
 
 const formatDuration = (seconds?: number) => {
   if (!seconds) return "—";
   const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
+  const secs = Math.floor(seconds % 60);
   return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
 
@@ -116,6 +126,7 @@ export const DetailPanelContent = ({
   loadVersionsAndStems,
 }: DetailPanelContentProps) => {
   const { isLiked, likeCount, toggleLike } = useTrackLike(track.id, track.like_count || 0);
+  const [selectedVersionId, setSelectedVersionId] = useState<string | undefined>();
 
   useEffect(() => {
     if (!track?.id) {
@@ -135,6 +146,35 @@ export const DetailPanelContent = ({
     }
   }, [track?.id, track.status]);
 
+  useEffect(() => {
+    if (!versions?.length) {
+      setSelectedVersionId(undefined);
+      return;
+    }
+
+    setSelectedVersionId((current) => {
+      if (current && versions.some((version) => version.id === current)) {
+        return current;
+      }
+
+      const masterVersion = versions.find((version) => version.is_master);
+      return masterVersion?.id ?? versions[0].id;
+    });
+  }, [versions]);
+
+  const activeVersion = useMemo(
+    () => versions.find((version) => version.id === selectedVersionId),
+    [versions, selectedVersionId]
+  );
+
+  const filteredStems = useMemo(() => {
+    if (!selectedVersionId) {
+      return stems;
+    }
+
+    return stems.filter((stem) => !stem.version_id || stem.version_id === selectedVersionId);
+  }, [stems, selectedVersionId]);
+
   const handlePresetApply = (preset: StylePreset) => {
     const presetGenre = preset.styleIds
       .map(styleId => getStyleById(styleId)?.name ?? styleId)
@@ -153,308 +193,281 @@ export const DetailPanelContent = ({
     setMood(tags.slice(0, 3).join(", "));
   };
 
+  const createdAtToDisplay = activeVersion?.created_at ?? track.created_at;
+  const durationToDisplay = activeVersion?.duration ?? track.duration_seconds;
+
   return (
     <TooltipProvider delayDuration={500}>
-    <div className="p-4 space-y-4">
-      {/* Quick Actions - только иконки */}
-      <div className="flex items-center justify-center gap-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button 
-              variant="ghost" 
-              size="icon"
-              className={cn(
-                "relative",
-                isLiked && "text-red-500"
-              )}
-              onClick={() => toggleLike()}
-            >
-              <Heart className={cn("h-5 w-5", isLiked && "fill-current")} />
-              {likeCount > 0 && (
-                <Badge className="absolute -top-1 -right-1 h-4 w-4 p-0 flex items-center justify-center text-[10px]">
-                  {likeCount}
-                </Badge>
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Избранное</TooltipContent>
-        </Tooltip>
+      <div className="p-4 sm:p-6 space-y-6 lg:space-y-8">
+        <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "relative",
+                  isLiked && "text-red-500"
+                )}
+                onClick={() => toggleLike()}
+              >
+                <Heart className={cn("h-5 w-5", isLiked && "fill-current")} />
+                {likeCount > 0 && (
+                  <Badge className="absolute -top-1 -right-1 h-4 w-4 p-0 flex items-center justify-center text-[10px]">
+                    {likeCount}
+                  </Badge>
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Избранное</TooltipContent>
+          </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              onClick={onDownload} 
-              disabled={!track.audio_url}
-            >
-              <Download className="h-5 w-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Скачать MP3</TooltipContent>
-        </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onDownload}
+                disabled={!track.audio_url}
+              >
+                <Download className="h-5 w-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Скачать MP3</TooltipContent>
+          </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={onShare}>
-              <Share2 className="h-5 w-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Поделиться</TooltipContent>
-        </Tooltip>
-      </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon" onClick={onShare}>
+                <Share2 className="h-5 w-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Поделиться</TooltipContent>
+          </Tooltip>
+        </div>
 
-      {/* Collapsible Sections */}
-      <Accordion type="multiple" defaultValue={["metadata"]} className="space-y-3">
-        {/* Versions */}
-        {versions.length > 0 && (
-          <AccordionItem value="versions" className="border rounded-lg px-4">
-            <AccordionTrigger className="text-sm py-3 hover:no-underline">
-              Версии ({versions.length})
-            </AccordionTrigger>
-            <AccordionContent className="pb-3">
-              <TrackVersions
-                trackId={track.id}
-                versions={versions}
-                onVersionUpdate={loadVersionsAndStems}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        )}
+        <TrackDetailsPanel track={track} activeVersion={activeVersion ?? null} />
 
-        {/* Stems */}
-        {track.status === 'completed' && track.audio_url && (
-          <AccordionItem value="stems" className="border rounded-lg px-4">
-            <AccordionTrigger className="text-sm py-3 hover:no-underline">
-              Стемы {stems.length > 0 && `(${stems.length})`}
-            </AccordionTrigger>
-            <AccordionContent className="pb-3">
-              <TrackStemsPanel
-                trackId={track.id}
-                stems={stems}
-                onStemsGenerated={loadVersionsAndStems}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {/* Metadata */}
-        <AccordionItem value="metadata" className="border rounded-lg px-4">
-          <AccordionTrigger className="text-sm py-3 hover:no-underline">
-            Метаданные
-          </AccordionTrigger>
-          <AccordionContent className="space-y-3 pb-3">
-            {/* Название без лейбла */}
-            <div className="relative">
-              <Input
-                id="title"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="Название трека"
-                className="h-10 text-sm"
-              />
-            </div>
-
-            {/* Жанр и Настроение в одной строке без лейблов */}
-            <div className="grid grid-cols-2 gap-3">
-              <div className="relative">
+        <div className="grid gap-4 lg:gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+          <div className="space-y-4 lg:space-y-6">
+            <Card className="border-border/70">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Метаданные</CardTitle>
+                <CardDescription>Обновите ключевую информацию и видимость трека.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
                 <Input
-                  id="genre"
-                  value={genre}
-                  onChange={(e) => setGenre(e.target.value)}
-                  placeholder="Жанр"
+                  id="title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="Название трека"
                   className="h-10 text-sm"
                 />
-              </div>
 
-              <div className="relative">
-                <Input
-                  id="mood"
-                  value={mood}
-                  onChange={(e) => setMood(e.target.value)}
-                  placeholder="Настроение"
-                  className="h-10 text-sm"
-                />
-              </div>
-            </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Input
+                    id="genre"
+                    value={genre}
+                    onChange={(e) => setGenre(e.target.value)}
+                    placeholder="Жанр"
+                    className="h-10 text-sm"
+                  />
 
-            <div className="flex items-center justify-between py-2">
-              <div className="space-y-0.5">
-                <Label className="text-sm">Публичный</Label>
-                <p className="text-xs text-muted-foreground">Доступен всем</p>
-              </div>
-              <Switch checked={isPublic} onCheckedChange={setIsPublic} />
-            </div>
-
-            <Button size="default" className="w-full" onClick={onSave} disabled={isSaving}>
-              {isSaving ? "Сохранение..." : "Сохранить"}
-            </Button>
-          </AccordionContent>
-        </AccordionItem>
-
-        <AccordionItem value="ai-style" className="border rounded-lg px-4">
-          <AccordionTrigger className="text-sm py-3 hover:no-underline">
-            AI рекомендации по стилю
-          </AccordionTrigger>
-          <AccordionContent className="pb-3">
-            <StyleRecommendationsPanel
-              mood={mood}
-              genre={genre}
-              context={track.prompt}
-              currentTags={track.style_tags ?? []}
-              onApplyPreset={handlePresetApply}
-              onApplyTags={handleTagsApply}
-            />
-          </AccordionContent>
-        </AccordionItem>
-
-        {/* Tags & Details */}
-        {(track.style_tags && track.style_tags.length > 0 || track.suno_id || track.model_name || track.lyrics) && (
-          <AccordionItem value="details" className="border rounded-lg px-4">
-            <AccordionTrigger className="text-sm py-3 hover:no-underline">
-              Детали
-            </AccordionTrigger>
-            <AccordionContent className="space-y-3 pb-3">
-              {/* Style Tags */}
-              {track.style_tags && track.style_tags.length > 0 && (
-                <div className="space-y-2">
-                  <Label className="text-sm">Теги стиля</Label>
-                  <div className="flex flex-wrap gap-1.5">
-                    {track.style_tags.map((tag: string, i: number) => (
-                      <Badge key={i} variant="secondary" className="text-xs px-2 py-0.5">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Suno Details */}
-              {(track.suno_id || track.model_name) && (
-                <div className="space-y-2">
-                  <Label className="text-sm">Генерация</Label>
-                  <div className="space-y-1 text-sm text-muted-foreground">
-                    {track.model_name && <p>Модель: {track.model_name}</p>}
-                    {track.suno_id && <p className="font-mono text-xs">ID: {track.suno_id}</p>}
-                  </div>
-                  
-                  {track.suno_id && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full justify-start h-9 text-sm"
-                      onClick={() => window.open(`https://suno.com/song/${track.suno_id}`, "_blank")}
-                    >
-                      <ExternalLink className="h-4 w-4 mr-2" />
-                      Открыть в Suno
-                    </Button>
-                  )}
-                  
-                  {track.video_url && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full justify-start h-9 text-sm"
-                      onClick={() => window.open(track.video_url, "_blank")}
-                    >
-                      <Play className="h-4 w-4 mr-2" />
-                      Видео
-                    </Button>
-                  )}
-                </div>
-              )}
-
-              {/* Lyrics */}
-              {track.lyrics && (
-                <div className="space-y-2">
-                  <Label className="text-sm">Текст</Label>
-                  <Textarea
-                    value={track.lyrics}
-                    readOnly
-                    className="min-h-[100px] resize-none text-sm"
+                  <Input
+                    id="mood"
+                    value={mood}
+                    onChange={(e) => setMood(e.target.value)}
+                    placeholder="Настроение"
+                    className="h-10 text-sm"
                   />
                 </div>
-              )}
-            </AccordionContent>
-          </AccordionItem>
-        )}
 
-        {/* Statistics - только иконки и цифры */}
-        <AccordionItem value="stats" className="border rounded-lg px-3">
-          <AccordionTrigger className="text-sm py-2 hover:no-underline">
-            Статистика
-          </AccordionTrigger>
-          <AccordionContent className="pb-2">
-            <div className="grid grid-cols-2 gap-3">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Eye className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium">{track.view_count || 0}</span>
+                <div className="flex items-center justify-between gap-4 rounded-md border border-border/60 bg-background/60 p-3">
+                  <div className="space-y-0.5">
+                    <Label className="text-sm">Публичный доступ</Label>
+                    <p className="text-xs text-muted-foreground">Трек будет доступен всем пользователям.</p>
                   </div>
-                </TooltipTrigger>
-                <TooltipContent>Просмотры</TooltipContent>
-              </Tooltip>
+                  <Switch checked={isPublic} onCheckedChange={setIsPublic} />
+                </div>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Heart className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium">{track.like_count || 0}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Лайки</TooltipContent>
-              </Tooltip>
+                <Button size="default" className="w-full" onClick={onSave} disabled={isSaving}>
+                  {isSaving ? "Сохранение..." : "Сохранить изменения"}
+                </Button>
+              </CardContent>
+            </Card>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Calendar className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium text-xs">{track.created_at ? formatDate(track.created_at) : '—'}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Дата создания</TooltipContent>
-              </Tooltip>
+            <Card className="border-border/70">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">AI рекомендации по стилю</CardTitle>
+                <CardDescription>Подберите подходящие жанры и теги с помощью ассистента.</CardDescription>
+              </CardHeader>
+              <CardContent className="pb-4">
+                <StyleRecommendationsPanel
+                  mood={mood}
+                  genre={genre}
+                  context={track.prompt}
+                  currentTags={track.style_tags ?? []}
+                  onApplyPreset={handlePresetApply}
+                  onApplyTags={handleTagsApply}
+                />
+              </CardContent>
+            </Card>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium">{formatDuration(track.duration_seconds)}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Длительность</TooltipContent>
-              </Tooltip>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
+            <Card className="border border-destructive/40 bg-destructive/5">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg text-destructive">Опасная зона</CardTitle>
+                <CardDescription>Удалите трек и все связанные данные без возможности восстановления.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="destructive" size="sm" className="w-full" onClick={onDelete}>
+                      <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                      Удалить трек
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Удалить трек безвозвратно</TooltipContent>
+                </Tooltip>
+              </CardContent>
+            </Card>
+          </div>
 
-        {/* Prompt */}
-        <AccordionItem value="prompt" className="border rounded-lg px-3">
-          <AccordionTrigger className="text-sm py-2 hover:no-underline">
-            Промпт
-          </AccordionTrigger>
-          <AccordionContent className="pb-2">
-            <div className="p-2 rounded-md bg-muted text-xs text-muted-foreground">
-              {track.prompt}
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
+          <div className="space-y-4 lg:space-y-6">
+            <Card className="border-border/70">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Версии трека</CardTitle>
+                <CardDescription>Переключайтесь между версиями и управляйте статусом.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <TrackVersionSelector
+                  versions={versions.map((version) => ({
+                    id: version.id,
+                    version_number: version.version_number,
+                    created_at: version.created_at,
+                    is_master: version.is_master,
+                  }))}
+                  selectedVersionId={selectedVersionId}
+                  onSelect={setSelectedVersionId}
+                />
+                <TrackVersions
+                  trackId={track.id}
+                  versions={versions}
+                  onVersionUpdate={loadVersionsAndStems}
+                />
+              </CardContent>
+            </Card>
 
-      {/* Danger Zone */}
-      <div className="pt-2 space-y-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="destructive" size="sm" className="w-full" onClick={onDelete}>
-              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-              Удалить трек
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Удалить трек безвозвратно</TooltipContent>
-        </Tooltip>
+            {track.status === 'completed' && track.audio_url && (
+              <Card className="border-border/70">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-lg">Стемы</CardTitle>
+                  <CardDescription>Создавайте и управляйте стемами выбранной версии.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <TrackStemsPanel
+                    trackId={track.id}
+                    versionId={selectedVersionId}
+                    stems={filteredStems}
+                    onStemsGenerated={loadVersionsAndStems}
+                  />
+                </CardContent>
+              </Card>
+            )}
+
+            <Card className="border-border/70">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Статистика</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-3 sm:grid-cols-2">
+                <StatsItem icon={Eye} label="Просмотры" value={`${track.view_count || 0}`} />
+                <StatsItem icon={Heart} label="Лайки" value={`${track.like_count || 0}`} />
+                <StatsItem icon={Calendar} label="Создан" value={formatDate(createdAtToDisplay)} />
+                <StatsItem icon={Clock} label="Длительность" value={formatDuration(durationToDisplay)} />
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/70">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Промпт</CardTitle>
+                <CardDescription>Исходный запрос, использованный при генерации трека.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="p-3 rounded-md bg-muted text-xs text-muted-foreground leading-relaxed whitespace-pre-wrap break-words">
+                  {track.prompt}
+                </div>
+              </CardContent>
+            </Card>
+
+            {(track.suno_id || track.model_name || track.lyrics) && (
+              <Card className="border-border/70">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-lg">Детали генерации</CardTitle>
+                  <CardDescription>Дополнительные сведения о создании трека.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-muted-foreground">
+                  {(track.model_name || track.suno_id) && (
+                    <div className="space-y-2">
+                      {track.model_name && <p>Модель: {track.model_name}</p>}
+                      {track.suno_id && <p className="font-mono text-xs">ID: {track.suno_id}</p>}
+
+                      {track.suno_id && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full justify-start h-9 text-sm"
+                          onClick={() => window.open(`https://suno.com/song/${track.suno_id}`, "_blank")}
+                        >
+                          <ExternalLink className="h-4 w-4 mr-2" />
+                          Открыть в Suno
+                        </Button>
+                      )}
+
+                      {track.video_url && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full justify-start h-9 text-sm"
+                          onClick={() => window.open(track.video_url, "_blank")}
+                        >
+                          <Play className="h-4 w-4 mr-2" />
+                          Видео
+                        </Button>
+                      )}
+                    </div>
+                  )}
+
+                  {track.lyrics && (
+                    <div className="space-y-2">
+                      <Label className="text-sm">Текст</Label>
+                      <Textarea
+                        value={track.lyrics}
+                        readOnly
+                        className="min-h-[120px] resize-none text-sm"
+                      />
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
       </div>
-    </div>
     </TooltipProvider>
   );
 };
+
+interface StatsItemProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+}
+
+const StatsItem = ({ icon: Icon, label, value }: StatsItemProps) => (
+  <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-background/60 p-3">
+    <div className="flex items-center gap-2 text-sm">
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <span className="text-muted-foreground">{label}</span>
+    </div>
+    <span className="font-medium text-sm">{value}</span>
+  </div>
+);

--- a/src/features/tracks/ui/DetailPanel.tsx
+++ b/src/features/tracks/ui/DetailPanel.tsx
@@ -19,6 +19,7 @@ interface TrackVersion {
   lyrics?: string;
   duration?: number;
   metadata?: Record<string, unknown>;
+  created_at?: string;
 }
 
 interface TrackStem {
@@ -26,6 +27,8 @@ interface TrackStem {
   stem_type: string;
   audio_url: string;
   separation_mode: string;
+  version_id?: string | null;
+  created_at?: string;
 }
 
 interface DetailPanelProps {
@@ -176,8 +179,8 @@ export const DetailPanel = ({ track, onClose, onUpdate, onDelete }: DetailPanelP
         .order('version_number');
       
       if (versionsData) {
-        dispatch({ 
-          type: 'SET_VERSIONS', 
+        dispatch({
+          type: 'SET_VERSIONS',
           value: versionsData
             .filter(v => v.suno_id && v.audio_url)
             .map(v => ({
@@ -189,7 +192,8 @@ export const DetailPanel = ({ track, onClose, onUpdate, onDelete }: DetailPanelP
               cover_url: v.cover_url ?? undefined,
               lyrics: v.lyrics ?? undefined,
               duration: v.duration ?? undefined,
-              metadata: v.metadata as Record<string, unknown>
+              metadata: v.metadata as Record<string, unknown>,
+              created_at: v.created_at ?? undefined
             }))
         });
       }
@@ -201,7 +205,14 @@ export const DetailPanel = ({ track, onClose, onUpdate, onDelete }: DetailPanelP
         .eq('track_id', track.id);
       
       if (stemsData) {
-        dispatch({ type: 'SET_STEMS', value: stemsData });
+        dispatch({
+          type: 'SET_STEMS',
+          value: stemsData.map(stem => ({
+            ...stem,
+            version_id: 'version_id' in stem ? (stem as { version_id?: string | null }).version_id ?? null : undefined,
+            created_at: 'created_at' in stem ? (stem as { created_at?: string }).created_at ?? undefined : undefined,
+          })),
+        });
       }
     } catch (error) {
       console.error('Error loading versions and stems:', error);
@@ -297,12 +308,16 @@ export const DetailPanel = ({ track, onClose, onUpdate, onDelete }: DetailPanelP
   }, []);
 
   return (
-    <div className="h-full flex flex-col bg-card border-l border-border" role="complementary" aria-label="Панель деталей трека">
+    <div
+      className="h-full flex flex-col bg-card border-l border-border w-full max-w-full sm:max-w-md lg:max-w-xl xl:max-w-2xl"
+      role="complementary"
+      aria-label="Панель деталей трека"
+    >
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-background/95 backdrop-blur-sm sticky top-0 z-10">
+      <div className="flex flex-wrap items-start gap-3 justify-between p-3 sm:p-4 border-b border-border bg-background/95 backdrop-blur-sm sticky top-0 z-10">
         <div className="flex items-center gap-3 flex-1 min-w-0">
-          <Badge 
-            variant={track.status === "completed" ? "default" : "secondary"} 
+          <Badge
+            variant={track.status === "completed" ? "default" : "secondary"}
             className="text-xs shrink-0"
           >
             {track.status === "completed" ? "✅ Готов" : "⏳ В процессе"}

--- a/src/features/tracks/ui/TrackDetailsPanel.tsx
+++ b/src/features/tracks/ui/TrackDetailsPanel.tsx
@@ -1,0 +1,145 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface TrackDetailsPanelProps {
+  track: {
+    title: string;
+    cover_url?: string;
+    created_at?: string;
+    genre?: string | null;
+    mood?: string | null;
+    style_tags?: string[] | null;
+    status?: string;
+    metadata?: Record<string, unknown> | null;
+    duration_seconds?: number | null;
+    duration?: number | null;
+  };
+  activeVersion?: {
+    id: string;
+    version_number: number;
+    duration?: number | null;
+    created_at?: string | null;
+    is_master?: boolean;
+  } | null;
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleDateString("ru-RU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return "—";
+  }
+};
+
+const formatDuration = (value?: number | null) => {
+  if (!value || Number.isNaN(value)) {
+    return "—";
+  }
+
+  const minutes = Math.floor(value / 60);
+  const seconds = Math.floor(value % 60);
+
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
+const extractArtist = (metadata?: Record<string, unknown> | null) => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const artistKeys = ["artist", "artist_name", "artistName", "creator", "performer"] as const;
+
+  for (const key of artistKeys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+export const TrackDetailsPanel = ({ track, activeVersion }: TrackDetailsPanelProps) => {
+  const artist = extractArtist(track.metadata) ?? "Неизвестный артист";
+  const createdAt = activeVersion?.created_at ?? track.created_at;
+  const duration = activeVersion?.duration ?? track.duration_seconds ?? track.duration ?? null;
+
+  return (
+    <Card className="border-border/70 shadow-sm">
+      <CardContent className="p-4 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+          {track.cover_url && (
+            <div className="sm:w-32 sm:flex-shrink-0">
+              <div className="aspect-square rounded-lg overflow-hidden border border-border/60 shadow-md">
+                <img
+                  src={track.cover_url}
+                  alt={`Обложка трека ${track.title}`}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="flex-1 space-y-4">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-semibold leading-tight sm:text-xl">{track.title}</h2>
+                {track.status && (
+                  <Badge variant={track.status === "completed" ? "default" : "secondary"} className="text-xs">
+                    {track.status === "completed" ? "Готов" : track.status}
+                  </Badge>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground">{artist}</p>
+            </div>
+
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 text-sm">
+              <MetadataItem label="Версия" value={activeVersion ? `№ ${activeVersion.version_number}` : "—"} />
+              <MetadataItem label="Дата создания" value={formatDate(createdAt)} />
+              <MetadataItem label="Длительность" value={formatDuration(duration ?? undefined)} />
+              <MetadataItem label="Жанр" value={track.genre || "—"} />
+              <MetadataItem label="Настроение" value={track.mood || "—"} />
+              <MetadataItem
+                label="Статус"
+                value={track.status ? (track.status === "completed" ? "Завершён" : track.status) : "—"}
+              />
+            </div>
+
+            {track.style_tags && track.style_tags.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium">Теги стиля</h3>
+                <div className="flex flex-wrap gap-2">
+                  {track.style_tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="text-xs font-medium">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+interface MetadataItemProps {
+  label: string;
+  value: string;
+}
+
+const MetadataItem = ({ label, value }: MetadataItemProps) => (
+  <div className="flex flex-col gap-1 rounded-md border border-border/60 bg-background/60 p-3">
+    <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>
+    <span className={cn("text-sm font-medium", value === "—" && "text-muted-foreground")}>{value}</span>
+  </div>
+);

--- a/src/features/tracks/ui/TrackVersionSelector.tsx
+++ b/src/features/tracks/ui/TrackVersionSelector.tsx
@@ -1,0 +1,78 @@
+import { CalendarClock, Star } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+
+export interface TrackVersionSelectorOption {
+  id: string;
+  version_number: number;
+  created_at?: string | null;
+  is_master?: boolean;
+}
+
+interface TrackVersionSelectorProps {
+  versions: TrackVersionSelectorOption[];
+  selectedVersionId?: string;
+  onSelect?: (versionId: string) => void;
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "Дата неизвестна";
+  try {
+    return new Date(value).toLocaleDateString("ru-RU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch (error) {
+    console.error("Failed to format version date", error);
+    return "Дата неизвестна";
+  }
+};
+
+export const TrackVersionSelector = ({ versions, selectedVersionId, onSelect }: TrackVersionSelectorProps) => {
+  if (!versions?.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <CalendarClock className="h-4 w-4 text-muted-foreground" />
+        <span>Выбрать версию</span>
+        {versions.some((version) => version.is_master) && (
+          <Badge variant="outline" className="gap-1 text-xs">
+            <Star className="h-3 w-3" />
+            Главная
+          </Badge>
+        )}
+      </div>
+      <Select value={selectedVersionId ?? undefined} onValueChange={(value) => onSelect?.(value)}>
+        <SelectTrigger className="h-11 justify-between text-left">
+          <SelectValue placeholder="Выберите версию трека" />
+        </SelectTrigger>
+        <SelectContent className="max-h-64">
+          {versions.map((version) => (
+            <SelectItem key={version.id} value={version.id} className="flex items-center justify-between gap-2">
+              <div className="flex flex-col">
+                <span className="font-medium">Версия {version.version_number}</span>
+                <span className="text-xs text-muted-foreground">{formatDate(version.created_at)}</span>
+              </div>
+              {version.is_master && (
+                <Badge variant="secondary" className="gap-1 text-[11px]">
+                  <Star className="h-3 w-3" />
+                  Главная
+                </Badge>
+              )}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/features/tracks/ui/index.ts
+++ b/src/features/tracks/ui/index.ts
@@ -1,1 +1,3 @@
 export { DetailPanel } from './DetailPanel';
+export { TrackDetailsPanel } from './TrackDetailsPanel';
+export { TrackVersionSelector } from './TrackVersionSelector';


### PR DESCRIPTION
## Summary
- redesign the track detail panel content into a responsive card-based layout that surfaces quick actions, metadata editing, statistics, and prompt details
- add dedicated TrackDetailsPanel and TrackVersionSelector components to highlight track metadata and allow switching between versions with creation dates
- extend data loading to capture version metadata and version-aware stems, wiring TrackStemsPanel to the selected version

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors across docs, tests, and shared utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68e7c57a8ce8832f8d962424b360d73a