### PR TITLE
Refine detail panel layout responsivene

### DIFF
--- a/src/components/workspace/DetailPanelContent.tsx
+++ b/src/components/workspace/DetailPanelContent.tsx
@@ -1,68 +1,42 @@
-// import { useState } from "react";
-import { useEffect } from "react";
-import { Download, Share2, Trash2, Eye, Heart, Calendar, Clock, ExternalLink, Play } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Download,
+  Share2,
+  Trash2,
+  Eye,
+  Heart,
+  Calendar,
+  Clock,
+  ExternalLink,
+  Play,
+  CalendarClock,
+  Star,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-// import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrackVersions, TrackStemsPanel, useTrackLike } from "@/features/tracks";
+import { TrackDetailsPanel } from "@/features/tracks/ui/TrackDetailsPanel";
+import { TrackVersionSelector } from "@/features/tracks/ui/TrackVersionSelector";
 import { cn } from "@/lib/utils";
 import { StyleRecommendationsPanel } from "./StyleRecommendationsPanel";
 import type { StylePreset } from "@/types/styles";
 import { getStyleById } from "@/data/music-styles";
 import { AnalyticsService, viewSessionGuard } from "@/services/analytics.service";
-
-interface Track {
-  id: string;
-  title: string;
-  prompt: string;
-  status: string;
-  audio_url?: string;
-  cover_url?: string;
-  video_url?: string;
-  suno_id?: string;
-  genre?: string;
-  mood?: string;
-  is_public?: boolean;
-  created_at?: string;
-  user_id?: string;
-  duration?: number;
-  lyrics?: string;
-  metadata?: Record<string, unknown>;
-  like_count?: number;
-  view_count?: number;
-  duration_seconds?: number;
-  style_tags?: string[];
-  model_name?: string;
-}
-
-interface TrackVersion {
-  id: string;
-  version_number: number;
-  is_master: boolean;
-  suno_id: string;
-  audio_url: string;
-  video_url?: string;
-  cover_url?: string;
-  lyrics?: string;
-  duration?: number;
-  metadata?: Record<string, unknown>;
-}
-
-interface TrackStem {
-  id: string;
-  stem_type: string;
-  audio_url: string;
-  separation_mode: string;
-}
+import type {
+  DetailPanelTrack,
+  DetailPanelTrackVersion,
+  DetailPanelTrackStem,
+} from "@/types/track";
 
 interface DetailPanelContentProps {
-  track: Track;
+  track: DetailPanelTrack;
   title: string;
   setTitle: (value: string) => void;
   genre: string;
@@ -72,8 +46,8 @@ interface DetailPanelContentProps {
   isPublic: boolean;
   setIsPublic: (value: boolean) => void;
   isSaving: boolean;
-  versions: TrackVersion[];
-  stems: TrackStem[];
+  versions: DetailPanelTrackVersion[];
+  stems: DetailPanelTrackStem[];
   onSave: () => void;
   onDownload: () => void;
   onShare: () => void;
@@ -81,18 +55,24 @@ interface DetailPanelContentProps {
   loadVersionsAndStems: () => void;
 }
 
-const formatDate = (date: string) => {
-  return new Date(date).toLocaleDateString("ru-RU", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
+const formatDate = (date?: string | null) => {
+  if (!date) return "—";
+  try {
+    return new Date(date).toLocaleDateString("ru-RU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return "—";
+  }
 };
 
-const formatDuration = (seconds?: number) => {
+const formatDuration = (seconds?: number | null) => {
   if (!seconds) return "—";
   const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
+  const secs = Math.floor(seconds % 60);
   return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
 
@@ -115,7 +95,8 @@ export const DetailPanelContent = ({
   onDelete,
   loadVersionsAndStems,
 }: DetailPanelContentProps) => {
-  const { isLiked, likeCount, toggleLike } = useTrackLike(track.id, track.like_count || 0);
+  const { isLiked, likeCount, toggleLike } = useTrackLike(track.id, track.like_count ?? 0);
+  const [selectedVersionId, setSelectedVersionId] = useState<string | undefined>();
 
   useEffect(() => {
     if (!track?.id) {
@@ -125,19 +106,59 @@ export const DetailPanelContent = ({
     const hasView = viewSessionGuard.has(track.id);
 
     AnalyticsService.recordView(track.id).catch((error) => {
-      console.error('Failed to record track view', error);
+      console.error("Failed to record track view", error);
     });
 
-    if (track.status === 'completed' && !hasView) {
+    if (track.status === "completed" && !hasView) {
       AnalyticsService.recordPlay(track.id).catch((error) => {
-        console.error('Failed to record track play', error);
+        console.error("Failed to record track play", error);
       });
     }
   }, [track?.id, track.status]);
 
+  useEffect(() => {
+    if (!versions?.length) {
+      setSelectedVersionId(undefined);
+      return;
+    }
+
+    setSelectedVersionId((current) => {
+      if (current && versions.some((version) => version.id === current)) {
+        return current;
+      }
+
+      const masterVersion = versions.find((version) => version.is_master);
+      return masterVersion?.id ?? versions[0].id;
+    });
+  }, [versions]);
+
+  const activeVersion = useMemo(
+    () => versions.find((version) => version.id === selectedVersionId) ?? null,
+    [versions, selectedVersionId]
+  );
+
+  const filteredStems = useMemo(() => {
+    if (!selectedVersionId) {
+      return stems;
+    }
+
+    return stems.filter((stem) => !stem.version_id || stem.version_id === selectedVersionId);
+  }, [stems, selectedVersionId]);
+
+  const versionOptions = useMemo(
+    () =>
+      versions.map((version) => ({
+        id: version.id,
+        version_number: version.version_number,
+        created_at: version.created_at,
+        is_master: Boolean(version.is_master),
+      })),
+    [versions]
+  );
+
   const handlePresetApply = (preset: StylePreset) => {
     const presetGenre = preset.styleIds
-      .map(styleId => getStyleById(styleId)?.name ?? styleId)
+      .map((styleId) => getStyleById(styleId)?.name ?? styleId)
       .join(", ");
 
     if (presetGenre) {
@@ -153,308 +174,442 @@ export const DetailPanelContent = ({
     setMood(tags.slice(0, 3).join(", "));
   };
 
+  const createdAtToDisplay = activeVersion?.created_at ?? track.created_at ?? null;
+  const durationToDisplay = activeVersion?.duration ?? track.duration_seconds ?? track.duration ?? null;
+  const shouldRenderStemsCard = Boolean(track.audio_url) || filteredStems.length > 0;
+  const hasGenerationDetails = Boolean(track.suno_id || track.model_name || track.lyrics || track.video_url);
+
   return (
     <TooltipProvider delayDuration={500}>
-    <div className="p-4 space-y-4">
-      {/* Quick Actions - только иконки */}
-      <div className="flex items-center justify-center gap-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button 
-              variant="ghost" 
-              size="icon"
-              className={cn(
-                "relative",
-                isLiked && "text-red-500"
-              )}
-              onClick={() => toggleLike()}
-            >
-              <Heart className={cn("h-5 w-5", isLiked && "fill-current")} />
-              {likeCount > 0 && (
-                <Badge className="absolute -top-1 -right-1 h-4 w-4 p-0 flex items-center justify-center text-[10px]">
-                  {likeCount}
-                </Badge>
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Избранное</TooltipContent>
-        </Tooltip>
+      <div className="space-y-6 p-4 sm:space-y-7 sm:p-6">
+        <ActionToolbar
+          isLiked={isLiked}
+          likeCount={likeCount}
+          onToggleLike={toggleLike}
+          onDownload={onDownload}
+          onShare={onShare}
+          hasAudio={Boolean(track.audio_url)}
+        />
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              onClick={onDownload} 
-              disabled={!track.audio_url}
-            >
-              <Download className="h-5 w-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Скачать MP3</TooltipContent>
-        </Tooltip>
+        <TrackDetailsPanel track={track} activeVersion={activeVersion} />
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={onShare}>
-              <Share2 className="h-5 w-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Поделиться</TooltipContent>
-        </Tooltip>
-      </div>
+        <div className="grid gap-4 sm:gap-5 lg:gap-6 lg:grid-cols-2 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+          <div className="space-y-4 sm:space-y-5 lg:space-y-6">
+            <MetadataCard
+              title={title}
+              genre={genre}
+              mood={mood}
+              isPublic={isPublic}
+              onTitleChange={setTitle}
+              onGenreChange={setGenre}
+              onMoodChange={setMood}
+              onVisibilityChange={setIsPublic}
+              onSave={onSave}
+              isSaving={isSaving}
+            />
 
-      {/* Collapsible Sections */}
-      <Accordion type="multiple" defaultValue={["metadata"]} className="space-y-3">
-        {/* Versions */}
-        {versions.length > 0 && (
-          <AccordionItem value="versions" className="border rounded-lg px-4">
-            <AccordionTrigger className="text-sm py-3 hover:no-underline">
-              Версии ({versions.length})
-            </AccordionTrigger>
-            <AccordionContent className="pb-3">
-              <TrackVersions
-                trackId={track.id}
-                versions={versions}
-                onVersionUpdate={loadVersionsAndStems}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {/* Stems */}
-        {track.status === 'completed' && track.audio_url && (
-          <AccordionItem value="stems" className="border rounded-lg px-4">
-            <AccordionTrigger className="text-sm py-3 hover:no-underline">
-              Стемы {stems.length > 0 && `(${stems.length})`}
-            </AccordionTrigger>
-            <AccordionContent className="pb-3">
-              <TrackStemsPanel
-                trackId={track.id}
-                stems={stems}
-                onStemsGenerated={loadVersionsAndStems}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {/* Metadata */}
-        <AccordionItem value="metadata" className="border rounded-lg px-4">
-          <AccordionTrigger className="text-sm py-3 hover:no-underline">
-            Метаданные
-          </AccordionTrigger>
-          <AccordionContent className="space-y-3 pb-3">
-            {/* Название без лейбла */}
-            <div className="relative">
-              <Input
-                id="title"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="Название трека"
-                className="h-10 text-sm"
-              />
-            </div>
-
-            {/* Жанр и Настроение в одной строке без лейблов */}
-            <div className="grid grid-cols-2 gap-3">
-              <div className="relative">
-                <Input
-                  id="genre"
-                  value={genre}
-                  onChange={(e) => setGenre(e.target.value)}
-                  placeholder="Жанр"
-                  className="h-10 text-sm"
-                />
-              </div>
-
-              <div className="relative">
-                <Input
-                  id="mood"
-                  value={mood}
-                  onChange={(e) => setMood(e.target.value)}
-                  placeholder="Настроение"
-                  className="h-10 text-sm"
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between py-2">
-              <div className="space-y-0.5">
-                <Label className="text-sm">Публичный</Label>
-                <p className="text-xs text-muted-foreground">Доступен всем</p>
-              </div>
-              <Switch checked={isPublic} onCheckedChange={setIsPublic} />
-            </div>
-
-            <Button size="default" className="w-full" onClick={onSave} disabled={isSaving}>
-              {isSaving ? "Сохранение..." : "Сохранить"}
-            </Button>
-          </AccordionContent>
-        </AccordionItem>
-
-        <AccordionItem value="ai-style" className="border rounded-lg px-4">
-          <AccordionTrigger className="text-sm py-3 hover:no-underline">
-            AI рекомендации по стилю
-          </AccordionTrigger>
-          <AccordionContent className="pb-3">
-            <StyleRecommendationsPanel
+            <RecommendationsCard
               mood={mood}
               genre={genre}
-              context={track.prompt}
-              currentTags={track.style_tags ?? []}
+              prompt={track.prompt ?? ""}
+              styleTags={track.style_tags ?? []}
               onApplyPreset={handlePresetApply}
               onApplyTags={handleTagsApply}
             />
-          </AccordionContent>
-        </AccordionItem>
 
-        {/* Tags & Details */}
-        {(track.style_tags && track.style_tags.length > 0 || track.suno_id || track.model_name || track.lyrics) && (
-          <AccordionItem value="details" className="border rounded-lg px-4">
-            <AccordionTrigger className="text-sm py-3 hover:no-underline">
-              Детали
-            </AccordionTrigger>
-            <AccordionContent className="space-y-3 pb-3">
-              {/* Style Tags */}
-              {track.style_tags && track.style_tags.length > 0 && (
-                <div className="space-y-2">
-                  <Label className="text-sm">Теги стиля</Label>
-                  <div className="flex flex-wrap gap-1.5">
-                    {track.style_tags.map((tag: string, i: number) => (
-                      <Badge key={i} variant="secondary" className="text-xs px-2 py-0.5">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
+            <DangerZoneCard onDelete={onDelete} />
+          </div>
 
-              {/* Suno Details */}
-              {(track.suno_id || track.model_name) && (
-                <div className="space-y-2">
-                  <Label className="text-sm">Генерация</Label>
-                  <div className="space-y-1 text-sm text-muted-foreground">
-                    {track.model_name && <p>Модель: {track.model_name}</p>}
-                    {track.suno_id && <p className="font-mono text-xs">ID: {track.suno_id}</p>}
-                  </div>
-                  
-                  {track.suno_id && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full justify-start h-9 text-sm"
-                      onClick={() => window.open(`https://suno.com/song/${track.suno_id}`, "_blank")}
-                    >
-                      <ExternalLink className="h-4 w-4 mr-2" />
-                      Открыть в Suno
-                    </Button>
-                  )}
-                  
-                  {track.video_url && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full justify-start h-9 text-sm"
-                      onClick={() => window.open(track.video_url, "_blank")}
-                    >
-                      <Play className="h-4 w-4 mr-2" />
-                      Видео
-                    </Button>
-                  )}
-                </div>
-              )}
+          <div className="space-y-4 sm:space-y-5 lg:space-y-6">
+            <VersionsCard
+              trackId={track.id}
+              versions={versions}
+              options={versionOptions}
+              selectedVersionId={selectedVersionId}
+              onSelectVersion={setSelectedVersionId}
+              onVersionUpdate={loadVersionsAndStems}
+            />
 
-              {/* Lyrics */}
-              {track.lyrics && (
-                <div className="space-y-2">
-                  <Label className="text-sm">Текст</Label>
-                  <Textarea
-                    value={track.lyrics}
-                    readOnly
-                    className="min-h-[100px] resize-none text-sm"
-                  />
-                </div>
-              )}
-            </AccordionContent>
-          </AccordionItem>
-        )}
+            {shouldRenderStemsCard && (
+              <StemsCard
+                trackId={track.id}
+                versionId={selectedVersionId}
+                stems={filteredStems}
+                onStemsGenerated={loadVersionsAndStems}
+              />
+            )}
 
-        {/* Statistics - только иконки и цифры */}
-        <AccordionItem value="stats" className="border rounded-lg px-3">
-          <AccordionTrigger className="text-sm py-2 hover:no-underline">
-            Статистика
-          </AccordionTrigger>
-          <AccordionContent className="pb-2">
-            <div className="grid grid-cols-2 gap-3">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Eye className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium">{track.view_count || 0}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Просмотры</TooltipContent>
-              </Tooltip>
+            <StatsCard
+              views={track.view_count || 0}
+              likes={track.like_count || 0}
+              createdAt={formatDate(createdAtToDisplay)}
+              duration={formatDuration(durationToDisplay)}
+            />
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Heart className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium">{track.like_count || 0}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Лайки</TooltipContent>
-              </Tooltip>
+            <PromptCard prompt={track.prompt ?? "—"} />
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Calendar className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium text-xs">{track.created_at ? formatDate(track.created_at) : '—'}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Дата создания</TooltipContent>
-              </Tooltip>
-
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-medium">{formatDuration(track.duration_seconds)}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Длительность</TooltipContent>
-              </Tooltip>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-
-        {/* Prompt */}
-        <AccordionItem value="prompt" className="border rounded-lg px-3">
-          <AccordionTrigger className="text-sm py-2 hover:no-underline">
-            Промпт
-          </AccordionTrigger>
-          <AccordionContent className="pb-2">
-            <div className="p-2 rounded-md bg-muted text-xs text-muted-foreground">
-              {track.prompt}
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-
-      {/* Danger Zone */}
-      <div className="pt-2 space-y-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="destructive" size="sm" className="w-full" onClick={onDelete}>
-              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-              Удалить трек
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Удалить трек безвозвратно</TooltipContent>
-        </Tooltip>
+            {hasGenerationDetails && (
+              <GenerationDetailsCard
+                modelName={track.model_name}
+                sunoId={track.suno_id}
+                videoUrl={track.video_url}
+                lyrics={track.lyrics}
+              />
+            )}
+          </div>
+        </div>
       </div>
-    </div>
     </TooltipProvider>
   );
 };
+
+interface ActionToolbarProps {
+  isLiked: boolean;
+  likeCount: number;
+  hasAudio: boolean;
+  onToggleLike: () => void;
+  onDownload: () => void;
+  onShare: () => void;
+}
+
+const ActionToolbar = ({ isLiked, likeCount, hasAudio, onToggleLike, onDownload, onShare }: ActionToolbarProps) => (
+  <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn("relative", isLiked && "text-red-500")}
+          onClick={onToggleLike}
+        >
+          <Heart className={cn("h-5 w-5", isLiked && "fill-current")} />
+          {likeCount > 0 && (
+            <Badge className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center p-0 text-[10px]">
+              {likeCount}
+            </Badge>
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Избранное</TooltipContent>
+    </Tooltip>
+
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" onClick={onDownload} disabled={!hasAudio}>
+          <Download className="h-5 w-5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Скачать MP3</TooltipContent>
+    </Tooltip>
+
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" onClick={onShare}>
+          <Share2 className="h-5 w-5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Поделиться</TooltipContent>
+    </Tooltip>
+  </div>
+);
+
+interface MetadataCardProps {
+  title: string;
+  genre: string;
+  mood: string;
+  isPublic: boolean;
+  isSaving: boolean;
+  onTitleChange: (value: string) => void;
+  onGenreChange: (value: string) => void;
+  onMoodChange: (value: string) => void;
+  onVisibilityChange: (value: boolean) => void;
+  onSave: () => void;
+}
+
+const MetadataCard = ({
+  title,
+  genre,
+  mood,
+  isPublic,
+  isSaving,
+  onTitleChange,
+  onGenreChange,
+  onMoodChange,
+  onVisibilityChange,
+  onSave,
+}: MetadataCardProps) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">Метаданные</CardTitle>
+      <CardDescription>Обновите ключевую информацию и видимость трека.</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      <Input
+        id="title"
+        value={title}
+        onChange={(event) => onTitleChange(event.target.value)}
+        placeholder="Название трека"
+        className="h-10 text-sm"
+      />
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Input
+          id="genre"
+          value={genre}
+          onChange={(event) => onGenreChange(event.target.value)}
+          placeholder="Жанр"
+          className="h-10 text-sm"
+        />
+
+        <Input
+          id="mood"
+          value={mood}
+          onChange={(event) => onMoodChange(event.target.value)}
+          placeholder="Настроение"
+          className="h-10 text-sm"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-4 rounded-md border border-border/60 bg-background/60 p-3">
+        <div className="space-y-0.5">
+          <Label className="text-sm">Публичный доступ</Label>
+          <p className="text-xs text-muted-foreground">Трек будет доступен всем пользователям.</p>
+        </div>
+        <Switch checked={isPublic} onCheckedChange={onVisibilityChange} />
+      </div>
+
+      <Button size="default" className="w-full" onClick={onSave} disabled={isSaving}>
+        {isSaving ? "Сохранение..." : "Сохранить изменения"}
+      </Button>
+    </CardContent>
+  </Card>
+);
+
+interface RecommendationsCardProps {
+  mood: string;
+  genre: string;
+  prompt: string;
+  styleTags: string[];
+  onApplyPreset: (preset: StylePreset) => void;
+  onApplyTags: (tags: string[]) => void;
+}
+
+const RecommendationsCard = ({ mood, genre, prompt, styleTags, onApplyPreset, onApplyTags }: RecommendationsCardProps) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">AI рекомендации по стилю</CardTitle>
+      <CardDescription>Подберите подходящие жанры и теги с помощью ассистента.</CardDescription>
+    </CardHeader>
+    <CardContent className="pb-4">
+      <StyleRecommendationsPanel
+        mood={mood}
+        genre={genre}
+        context={prompt}
+        currentTags={styleTags}
+        onApplyPreset={onApplyPreset}
+        onApplyTags={onApplyTags}
+      />
+    </CardContent>
+  </Card>
+);
+
+const DangerZoneCard = ({ onDelete }: { onDelete: () => void }) => (
+  <Card className="border border-destructive/40 bg-destructive/5">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg text-destructive">Опасная зона</CardTitle>
+      <CardDescription>Удалите трек и все связанные данные без возможности восстановления.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="destructive" size="sm" className="w-full" onClick={onDelete}>
+            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+            Удалить трек
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Удалить трек безвозвратно</TooltipContent>
+      </Tooltip>
+    </CardContent>
+  </Card>
+);
+
+interface VersionsCardProps {
+  trackId: string;
+  versions: DetailPanelTrackVersion[];
+  options: Array<{
+    id: string;
+    version_number: number;
+    created_at?: string | null;
+    is_master?: boolean;
+  }>;
+  selectedVersionId?: string;
+  onSelectVersion: (versionId: string) => void;
+  onVersionUpdate: () => void;
+}
+
+const VersionsCard = ({
+  trackId,
+  versions,
+  options,
+  selectedVersionId,
+  onSelectVersion,
+  onVersionUpdate,
+}: VersionsCardProps) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">Версии трека</CardTitle>
+      <CardDescription>Переключайтесь между версиями и управляйте статусом.</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <CalendarClock className="h-4 w-4 text-muted-foreground" />
+          <span>Выбрать версию</span>
+          {options.some((version) => version.is_master) && (
+            <Badge variant="outline" className="gap-1 text-xs">
+              <Star className="h-3 w-3" />
+              Главная
+            </Badge>
+          )}
+        </div>
+        <TrackVersionSelector
+          versions={options}
+          selectedVersionId={selectedVersionId}
+          onSelect={onSelectVersion}
+        />
+      </div>
+      <TrackVersions trackId={trackId} versions={versions} onVersionUpdate={onVersionUpdate} />
+    </CardContent>
+  </Card>
+);
+
+interface StemsCardProps {
+  trackId: string;
+  versionId?: string;
+  stems: DetailPanelTrackStem[];
+  onStemsGenerated: () => void;
+}
+
+const StemsCard = ({ trackId, versionId, stems, onStemsGenerated }: StemsCardProps) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">Стемы</CardTitle>
+      <CardDescription>Создавайте и управляйте стемами выбранной версии.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <TrackStemsPanel
+        trackId={trackId}
+        versionId={versionId}
+        stems={stems}
+        onStemsGenerated={onStemsGenerated}
+      />
+    </CardContent>
+  </Card>
+);
+
+interface StatsCardProps {
+  views: number;
+  likes: number;
+  createdAt: string;
+  duration: string;
+}
+
+const StatsCard = ({ views, likes, createdAt, duration }: StatsCardProps) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">Статистика</CardTitle>
+    </CardHeader>
+    <CardContent className="grid gap-3 sm:grid-cols-2">
+      <StatsItem icon={Eye} label="Просмотры" value={`${views}`} />
+      <StatsItem icon={Heart} label="Лайки" value={`${likes}`} />
+      <StatsItem icon={Calendar} label="Создан" value={createdAt} />
+      <StatsItem icon={Clock} label="Длительность" value={duration} />
+    </CardContent>
+  </Card>
+);
+
+const PromptCard = ({ prompt }: { prompt: string }) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">Промпт</CardTitle>
+      <CardDescription>Исходный запрос, использованный при генерации трека.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-xs leading-relaxed text-muted-foreground">
+        {prompt}
+      </div>
+    </CardContent>
+  </Card>
+);
+
+interface GenerationDetailsCardProps {
+  modelName?: string | null;
+  sunoId?: string | null;
+  videoUrl?: string | null;
+  lyrics?: string | null;
+}
+
+const GenerationDetailsCard = ({ modelName, sunoId, videoUrl, lyrics }: GenerationDetailsCardProps) => (
+  <Card className="border-border/70">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-lg">Детали генерации</CardTitle>
+      <CardDescription>Дополнительные сведения о создании трека.</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-4 text-sm text-muted-foreground">
+      {(modelName || sunoId) && (
+        <div className="space-y-2">
+          {modelName && <p>Модель: {modelName}</p>}
+          {sunoId && <p className="font-mono text-xs">ID: {sunoId}</p>}
+
+          {sunoId && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 w-full justify-start text-sm"
+              onClick={() => window.open(`https://suno.com/song/${sunoId}`, "_blank")}
+            >
+              <ExternalLink className="mr-2 h-4 w-4" />
+              Открыть в Suno
+            </Button>
+          )}
+
+          {videoUrl && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 w-full justify-start text-sm"
+              onClick={() => window.open(videoUrl, "_blank")}
+            >
+              <Play className="mr-2 h-4 w-4" />
+              Видео
+            </Button>
+          )}
+        </div>
+      )}
+
+      {lyrics && (
+        <div className="space-y-2">
+          <Label className="text-sm">Текст</Label>
+          <Textarea value={lyrics} readOnly className="min-h-[120px] resize-none text-sm" />
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+interface StatsItemProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+}
+
+const StatsItem = ({ icon: Icon, label, value }: StatsItemProps) => (
+  <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-background/60 p-3">
+    <div className="flex items-center gap-2 text-sm">
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <span className="text-muted-foreground">{label}</span>
+    </div>
+    <span className="text-sm font-medium">{value}</span>
+  </div>
+);
+

--- a/src/features/tracks/ui/TrackDetailsPanel.tsx
+++ b/src/features/tracks/ui/TrackDetailsPanel.tsx
@@ -1,0 +1,149 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Disc3 } from "lucide-react";
+
+interface TrackDetailsPanelProps {
+  track: {
+    title: string;
+    cover_url?: string | null;
+    created_at?: string | null;
+    genre?: string | null;
+    mood?: string | null;
+    style_tags?: string[] | null;
+    status?: string | null;
+    metadata?: Record<string, unknown> | null;
+    duration_seconds?: number | null;
+    duration?: number | null;
+  };
+  activeVersion?: {
+    id: string;
+    version_number: number;
+    duration?: number | null;
+    created_at?: string | null;
+    is_master?: boolean;
+  } | null;
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleDateString("ru-RU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return "—";
+  }
+};
+
+const formatDuration = (value?: number | null) => {
+  if (!value || Number.isNaN(value)) {
+    return "—";
+  }
+
+  const minutes = Math.floor(value / 60);
+  const seconds = Math.floor(value % 60);
+
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
+const extractArtist = (metadata?: Record<string, unknown> | null) => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const artistKeys = ["artist", "artist_name", "artistName", "creator", "performer"] as const;
+
+  for (const key of artistKeys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+export const TrackDetailsPanel = ({ track, activeVersion }: TrackDetailsPanelProps) => {
+  const artist = extractArtist(track.metadata) ?? "Неизвестный артист";
+  const createdAt = activeVersion?.created_at ?? track.created_at;
+  const duration = activeVersion?.duration ?? track.duration_seconds ?? track.duration ?? null;
+  const coverUrl = track.cover_url ?? undefined;
+
+  return (
+    <Card className="border-border/70 shadow-sm">
+      <CardContent className="p-4 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+          <div className="sm:w-32 sm:flex-shrink-0">
+            <div className="aspect-square rounded-lg overflow-hidden border border-border/60 shadow-md flex items-center justify-center bg-muted/40">
+              {coverUrl ? (
+                <img
+                  src={coverUrl}
+                  alt={`Обложка трека ${track.title}`}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              ) : (
+                <Disc3 className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
+              )}
+            </div>
+          </div>
+
+          <div className="flex-1 space-y-4">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-semibold leading-tight sm:text-xl">{track.title}</h2>
+                {track.status && (
+                  <Badge variant={track.status === "completed" ? "default" : "secondary"} className="text-xs">
+                    {track.status === "completed" ? "Готов" : track.status}
+                  </Badge>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground">{artist}</p>
+            </div>
+
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 text-sm">
+              <MetadataItem label="Версия" value={activeVersion ? `№ ${activeVersion.version_number}` : "—"} />
+              <MetadataItem label="Дата создания" value={formatDate(createdAt)} />
+              <MetadataItem label="Длительность" value={formatDuration(duration ?? undefined)} />
+              <MetadataItem label="Жанр" value={track.genre || "—"} />
+              <MetadataItem label="Настроение" value={track.mood || "—"} />
+              <MetadataItem
+                label="Статус"
+                value={track.status ? (track.status === "completed" ? "Завершён" : track.status) : "—"}
+              />
+            </div>
+
+            {track.style_tags && track.style_tags.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium">Теги стиля</h3>
+                <div className="flex flex-wrap gap-2">
+                  {track.style_tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="text-xs font-medium">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+interface MetadataItemProps {
+  label: string;
+  value: string;
+}
+
+const MetadataItem = ({ label, value }: MetadataItemProps) => (
+  <div className="flex flex-col gap-1 rounded-md border border-border/60 bg-background/60 p-3">
+    <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>
+    <span className={cn("text-sm font-medium", value === "—" && "text-muted-foreground")}>{value}</span>
+  </div>
+);

--- a/src/features/tracks/ui/TrackVersionSelector.tsx
+++ b/src/features/tracks/ui/TrackVersionSelector.tsx
@@ -1,0 +1,88 @@
+import { CalendarClock, Star } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+
+export interface TrackVersionSelectorOption {
+  id: string;
+  version_number: number;
+  created_at?: string | null;
+  is_master?: boolean;
+}
+
+interface TrackVersionSelectorProps {
+  versions: TrackVersionSelectorOption[];
+  selectedVersionId?: string;
+  onSelect?: (versionId: string) => void;
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "Дата неизвестна";
+  try {
+    return new Date(value).toLocaleDateString("ru-RU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch (error) {
+    console.error("Failed to format version date", error);
+    return "Дата неизвестна";
+  }
+};
+
+export const TrackVersionSelector = ({ versions, selectedVersionId, onSelect }: TrackVersionSelectorProps) => {
+  if (!versions?.length) {
+    return null;
+  }
+
+  const sortedVersions = [...versions].sort((a, b) => {
+    if (a.version_number !== b.version_number) {
+      return b.version_number - a.version_number;
+    }
+
+    const aDate = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const bDate = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return bDate - aDate;
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <CalendarClock className="h-4 w-4 text-muted-foreground" />
+        <span>Выбрать версию</span>
+        {versions.some((version) => version.is_master) && (
+          <Badge variant="outline" className="gap-1 text-xs">
+            <Star className="h-3 w-3" />
+            Главная
+          </Badge>
+        )}
+      </div>
+      <Select value={selectedVersionId ?? undefined} onValueChange={(value) => onSelect?.(value)}>
+        <SelectTrigger className="h-11 justify-between text-left">
+          <SelectValue placeholder="Выберите версию трека" />
+        </SelectTrigger>
+        <SelectContent className="max-h-64">
+          {sortedVersions.map((version) => (
+            <SelectItem key={version.id} value={version.id} className="flex items-center justify-between gap-2">
+              <div className="flex flex-col">
+                <span className="font-medium">Версия {version.version_number}</span>
+                <span className="text-xs text-muted-foreground">{formatDate(version.created_at)}</span>
+              </div>
+              {version.is_master && (
+                <Badge variant="secondary" className="gap-1 text-[11px]">
+                  <Star className="h-3 w-3" />
+                  Главная
+                </Badge>
+              )}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/features/tracks/ui/index.ts
+++ b/src/features/tracks/ui/index.ts
@@ -1,1 +1,3 @@
 export { DetailPanel } from './DetailPanel';
+export { TrackDetailsPanel } from './TrackDetailsPanel';
+export { TrackVersionSelector } from './TrackVersionSelector';

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -195,3 +195,35 @@ export const convertToOptimizedTrack = (track: BaseTrack | DisplayTrack): Optimi
     has_stems: track.has_stems || false,
   };
 };
+
+export type DetailPanelTrack = DisplayTrack & {
+  prompt: string;
+  status: string;
+  audio_url?: string | null;
+  cover_url?: string | null;
+  video_url?: string | null;
+  suno_id?: string | null;
+  model_name?: string | null;
+  lyrics?: string | null;
+  genre?: string | null;
+  mood?: string | null;
+  is_public?: boolean | null;
+  view_count?: number | null;
+  like_count?: number | null;
+  has_stems?: boolean | null;
+  metadata?: Record<string, unknown> | null;
+  user_id?: string | null;
+};
+
+export type DetailPanelTrackVersion = TrackVersion & {
+  created_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+  duration?: number | null;
+  audio_url: string;
+  suno_id: string | null;
+};
+
+export type DetailPanelTrackStem = TrackStem & {
+  version_id?: string | null;
+  created_at?: string | null;
+};


### PR DESCRIPTION
## Summary
- restructure the detail panel content into focused subcards for actions, metadata, versions, stems, stats, and prompts to improve readability and reuse
- add memoized version options and responsive two-column breakpoints so versions, stems, and metadata adapt cleanly across device sizes
- gate the generation details card on available data while preserving consistent formatting for timestamps and durations

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7c57a8ce8832f8d962424b360d73a