### PR TITLE
feat: add AB controls to track version selector

### DIFF
--- a/src/features/tracks/ui/TrackVersionSelector.tsx
+++ b/src/features/tracks/ui/TrackVersionSelector.tsx
@@ -1,4 +1,5 @@
-import { CalendarClock, Star } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CalendarClock, Star, Play, Pause, ArrowLeftRight } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -7,6 +8,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useAudioPlayer } from "@/contexts/AudioPlayerContext";
+import { cn } from "@/lib/utils";
 
 export interface TrackVersionSelectorOption {
   id: string;
@@ -40,8 +44,139 @@ export const TrackVersionSelector = ({ versions, selectedVersionId, onSelect }: 
     return null;
   }
 
+  const { currentTrack, isPlaying, switchToVersion, togglePlayPause } = useAudioPlayer();
+  const currentTrackId = currentTrack?.id;
+
+  const [primarySelection, setPrimarySelection] = useState<string | undefined>(
+    selectedVersionId ?? versions[0]?.id,
+  );
+  const [secondarySelection, setSecondarySelection] = useState<string | undefined>(() =>
+    versions.find((version) => version.id !== (selectedVersionId ?? versions[0]?.id))?.id,
+  );
+  const [activeSlot, setActiveSlot] = useState<"primary" | "secondary">("primary");
+
+  const primaryVersion = useMemo(
+    () => versions.find((version) => version.id === primarySelection),
+    [primarySelection, versions],
+  );
+  const secondaryVersion = useMemo(
+    () => versions.find((version) => version.id === secondarySelection),
+    [secondarySelection, versions],
+  );
+
+  const activeVersionId = activeSlot === "primary" ? primarySelection : secondarySelection;
+
+  useEffect(() => {
+    if (selectedVersionId && selectedVersionId !== primarySelection) {
+      setPrimarySelection(selectedVersionId);
+      setActiveSlot("primary");
+    }
+  }, [selectedVersionId, primarySelection]);
+
+  useEffect(() => {
+    if (primarySelection && !versions.some((version) => version.id === primarySelection)) {
+      const fallbackPrimary = versions[0]?.id;
+      if (fallbackPrimary !== primarySelection) {
+        setPrimarySelection(fallbackPrimary);
+      }
+    }
+  }, [primarySelection, versions]);
+
+  useEffect(() => {
+    if (!secondarySelection || secondarySelection === primarySelection) {
+      const fallbackSecondary = versions.find((version) => version.id !== primarySelection)?.id;
+      if (fallbackSecondary !== secondarySelection) {
+        setSecondarySelection(fallbackSecondary);
+      }
+    }
+  }, [primarySelection, secondarySelection, versions]);
+
+  const handleSelectVersion = useCallback(
+    (versionId: string) => {
+      onSelect?.(versionId);
+      switchToVersion(versionId);
+    },
+    [onSelect, switchToVersion],
+  );
+
+  const handleManualSelect = useCallback(
+    (versionId: string) => {
+      if (activeSlot === "primary") {
+        setPrimarySelection(versionId);
+      } else {
+        setSecondarySelection(versionId);
+      }
+      handleSelectVersion(versionId);
+    },
+    [activeSlot, handleSelectVersion],
+  );
+
+  const handleAssignSlot = useCallback(
+    (slot: "primary" | "secondary", versionId: string, { play }: { play?: boolean } = {}) => {
+      if (slot === "primary") {
+        setPrimarySelection(versionId);
+      } else {
+        setSecondarySelection(versionId);
+      }
+
+      if (play) {
+        setActiveSlot(slot);
+        handleSelectVersion(versionId);
+      }
+    },
+    [handleSelectVersion],
+  );
+
+  const handleActivateSlot = useCallback(
+    (slot: "primary" | "secondary") => {
+      const versionId = slot === "primary" ? primarySelection : secondarySelection;
+      if (!versionId) return;
+
+      setActiveSlot(slot);
+      handleSelectVersion(versionId);
+    },
+    [handleSelectVersion, primarySelection, secondarySelection],
+  );
+
+  const handleFlipActive = useCallback(() => {
+    const nextSlot = activeSlot === "primary" ? "secondary" : "primary";
+    const versionId = nextSlot === "primary" ? primarySelection : secondarySelection;
+    if (!versionId) return;
+
+    setActiveSlot(nextSlot);
+    handleSelectVersion(versionId);
+  }, [activeSlot, handleSelectVersion, primarySelection, secondarySelection]);
+
+  const handlePlayPause = useCallback(
+    (versionId: string) => {
+      const isCurrent = currentTrackId === versionId;
+      if (isCurrent) {
+        togglePlayPause();
+        return;
+      }
+
+      if (primarySelection === versionId) {
+        setActiveSlot("primary");
+      } else if (secondarySelection === versionId) {
+        setActiveSlot("secondary");
+      } else {
+        setPrimarySelection(versionId);
+        setActiveSlot("primary");
+      }
+
+      handleSelectVersion(versionId);
+    },
+    [currentTrackId, handleSelectVersion, primarySelection, secondarySelection, togglePlayPause],
+  );
+
+  const getVersionLabel = useCallback(
+    (version?: TrackVersionSelectorOption) =>
+      version ? `Версия ${version.version_number}` : "Версия не выбрана",
+    [],
+  );
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <div className="flex items-center gap-2 text-sm font-medium">
         <CalendarClock className="h-4 w-4 text-muted-foreground" />
         <span>Выбрать версию</span>
@@ -52,13 +187,17 @@ export const TrackVersionSelector = ({ versions, selectedVersionId, onSelect }: 
           </Badge>
         )}
       </div>
-      <Select value={selectedVersionId ?? undefined} onValueChange={(value) => onSelect?.(value)}>
-        <SelectTrigger className="h-11 justify-between text-left">
+      <Select value={activeVersionId ?? undefined} onValueChange={handleManualSelect}>
+        <SelectTrigger className="h-11 justify-between text-left" aria-label="Выбор версии трека">
           <SelectValue placeholder="Выберите версию трека" />
         </SelectTrigger>
         <SelectContent className="max-h-64">
           {versions.map((version) => (
-            <SelectItem key={version.id} value={version.id} className="flex items-center justify-between gap-2">
+            <SelectItem
+              key={version.id}
+              value={version.id}
+              className="flex items-center justify-between gap-2"
+            >
               <div className="flex flex-col">
                 <span className="font-medium">Версия {version.version_number}</span>
                 <span className="text-xs text-muted-foreground">{formatDate(version.created_at)}</span>
@@ -73,6 +212,142 @@ export const TrackVersionSelector = ({ versions, selectedVersionId, onSelect }: 
           ))}
         </SelectContent>
       </Select>
+      <div
+        className="rounded-lg border border-border/60 bg-background/60 p-3 shadow-sm"
+        aria-label="Режим сравнения версий"
+      >
+        <div className="flex flex-wrap items-center gap-2 justify-between">
+          <div className="text-sm font-medium">Сравнение A/B</div>
+          <div className="flex items-center gap-2" role="group" aria-label="Управление сравнениями A/B">
+            <Button
+              type="button"
+              variant={activeSlot === "primary" ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleActivateSlot("primary")}
+              aria-pressed={activeSlot === "primary"}
+              aria-label="Слушать версию A"
+              disabled={!primarySelection}
+            >
+              Слушать A
+            </Button>
+            <Button
+              type="button"
+              variant={activeSlot === "secondary" ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleActivateSlot("secondary")}
+              aria-pressed={activeSlot === "secondary"}
+              aria-label="Слушать версию B"
+              disabled={!secondarySelection}
+            >
+              Слушать B
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleFlipActive}
+              aria-label="Переключить активную версию между A и B"
+              disabled={!primarySelection || !secondarySelection}
+            >
+              <ArrowLeftRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+        <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+          <div>
+            <span className="font-medium text-foreground">A:</span> {getVersionLabel(primaryVersion)}
+          </div>
+          <div>
+            <span className="font-medium text-foreground">B:</span> {getVersionLabel(secondaryVersion)}
+          </div>
+        </div>
+      </div>
+      <div className="space-y-2" role="list" aria-label="Список версий трека">
+        {versions.map((version) => {
+          const isCurrent = currentTrackId === version.id;
+          const isPlayingCurrent = isCurrent && isPlaying;
+          const isAssignedToPrimary = primarySelection === version.id;
+          const isAssignedToSecondary = secondarySelection === version.id;
+          const isActiveVersion =
+            (activeSlot === "primary" && isAssignedToPrimary) ||
+            (activeSlot === "secondary" && isAssignedToSecondary);
+
+          return (
+            <div
+              key={version.id}
+              role="listitem"
+              className={cn(
+                "flex items-center gap-3 rounded-lg border p-3 transition-colors focus-within:ring-2 focus-within:ring-primary/70",
+                isActiveVersion ? "border-primary/70 bg-primary/5" : "border-border/60 bg-background/40",
+              )}
+            >
+              <Button
+                type="button"
+                variant={isPlayingCurrent ? "default" : "outline"}
+                size="icon-sm"
+                aria-label={
+                  isCurrent
+                    ? isPlayingCurrent
+                      ? `Пауза версии ${version.version_number}`
+                      : `Продолжить версию ${version.version_number}`
+                    : `Воспроизвести версию ${version.version_number}`
+                }
+                aria-pressed={isPlayingCurrent}
+                onClick={() => handlePlayPause(version.id)}
+              >
+                {isPlayingCurrent ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+              </Button>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate font-medium">Версия {version.version_number}</span>
+                <span className="text-xs text-muted-foreground">{formatDate(version.created_at)}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {version.is_master && (
+                  <Badge variant="secondary" className="gap-1 text-[11px]">
+                    <Star className="h-3 w-3" />
+                    Главная
+                  </Badge>
+                )}
+                {isActiveVersion && (
+                  <Badge variant="outline" className="text-[11px]">
+                    Активна
+                  </Badge>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant={isAssignedToPrimary ? "default" : "outline"}
+                  size="icon-sm"
+                  aria-label={`Назначить версию ${version.version_number} как A`}
+                  aria-pressed={isAssignedToPrimary}
+                  onClick={() =>
+                    handleAssignSlot("primary", version.id, {
+                      play: activeSlot === "primary",
+                    })
+                  }
+                >
+                  A
+                </Button>
+                <Button
+                  type="button"
+                  variant={isAssignedToSecondary ? "default" : "outline"}
+                  size="icon-sm"
+                  aria-label={`Назначить версию ${version.version_number} как B`}
+                  aria-pressed={isAssignedToSecondary}
+                  onClick={() =>
+                    handleAssignSlot("secondary", version.id, {
+                      play: activeSlot === "secondary",
+                    })
+                  }
+                >
+                  B
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/src/features/tracks/ui/__tests__/TrackVersionSelector.test.tsx
+++ b/src/features/tracks/ui/__tests__/TrackVersionSelector.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TrackVersionSelector } from '../TrackVersionSelector';
+
+const audioPlayerMocks = vi.hoisted(() => ({
+  useAudioPlayerMock: vi.fn(),
+  switchToVersion: vi.fn(),
+  togglePlayPause: vi.fn(),
+  playTrack: vi.fn(),
+  playTrackWithQueue: vi.fn(),
+  pauseTrack: vi.fn(),
+  seekTo: vi.fn(),
+  setVolume: vi.fn(),
+  playNext: vi.fn(),
+  playPrevious: vi.fn(),
+  addToQueue: vi.fn(),
+  removeFromQueue: vi.fn(),
+  clearQueue: vi.fn(),
+  reorderQueue: vi.fn(),
+  getAvailableVersions: vi.fn(() => []),
+  clearCurrentTrack: vi.fn(),
+}));
+
+const createAudioPlayerValue = () => ({
+  currentTrack: null,
+  isPlaying: false,
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  queue: [],
+  currentQueueIndex: -1,
+  playTrack: audioPlayerMocks.playTrack,
+  playTrackWithQueue: audioPlayerMocks.playTrackWithQueue,
+  togglePlayPause: audioPlayerMocks.togglePlayPause,
+  pauseTrack: audioPlayerMocks.pauseTrack,
+  seekTo: audioPlayerMocks.seekTo,
+  setVolume: audioPlayerMocks.setVolume,
+  playNext: audioPlayerMocks.playNext,
+  playPrevious: audioPlayerMocks.playPrevious,
+  addToQueue: audioPlayerMocks.addToQueue,
+  removeFromQueue: audioPlayerMocks.removeFromQueue,
+  clearQueue: audioPlayerMocks.clearQueue,
+  reorderQueue: audioPlayerMocks.reorderQueue,
+  switchToVersion: audioPlayerMocks.switchToVersion,
+  getAvailableVersions: audioPlayerMocks.getAvailableVersions,
+  currentVersionIndex: 0,
+  audioRef: { current: null },
+  clearCurrentTrack: audioPlayerMocks.clearCurrentTrack,
+});
+
+vi.mock('@/contexts/AudioPlayerContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/AudioPlayerContext')>(
+    '@/contexts/AudioPlayerContext',
+  );
+
+  return {
+    ...actual,
+    useAudioPlayer: () => audioPlayerMocks.useAudioPlayerMock(),
+  };
+});
+
+beforeAll(() => {
+  Object.assign(Element.prototype, {
+    hasPointerCapture: () => false,
+    setPointerCapture: () => {},
+    releasePointerCapture: () => {},
+    scrollIntoView: () => {},
+  });
+});
+
+describe('TrackVersionSelector', () => {
+  const versions = [
+    {
+      id: 'version-a',
+      version_number: 1,
+      created_at: '2024-01-01T00:00:00.000Z',
+      is_master: true,
+    },
+    {
+      id: 'version-b',
+      version_number: 2,
+      created_at: '2024-02-01T00:00:00.000Z',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    audioPlayerMocks.useAudioPlayerMock.mockReturnValue(createAudioPlayerValue());
+  });
+
+  it('calls switchToVersion when selecting a new version from the list', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <TrackVersionSelector versions={versions} selectedVersionId={versions[0].id} onSelect={onSelect} />,
+    );
+
+    const trigger = screen.getByRole('combobox', { name: 'Выбор версии трека' });
+    await user.click(trigger);
+
+    const option = await screen.findByRole('option', { name: /Версия 2/ });
+    await user.click(option);
+
+    expect(onSelect).toHaveBeenCalledWith('version-b');
+    expect(audioPlayerMocks.switchToVersion).toHaveBeenCalledWith('version-b');
+  });
+
+  it('toggles play/pause when the current version is playing', async () => {
+    const user = userEvent.setup();
+
+    audioPlayerMocks.useAudioPlayerMock.mockReturnValue({
+      ...createAudioPlayerValue(),
+      currentTrack: { id: 'version-b' } as unknown,
+      isPlaying: true,
+      togglePlayPause: audioPlayerMocks.togglePlayPause,
+      switchToVersion: audioPlayerMocks.switchToVersion,
+    });
+
+    render(
+      <TrackVersionSelector versions={versions} selectedVersionId={versions[0].id} />,
+    );
+
+    const pauseButton = screen.getByRole('button', { name: 'Пауза версии 2' });
+    await user.click(pauseButton);
+
+    expect(audioPlayerMocks.togglePlayPause).toHaveBeenCalledTimes(1);
+    expect(audioPlayerMocks.switchToVersion).not.toHaveBeenCalled();
+  });
+
+  it('activates slot B playback through comparison controls', async () => {
+    const user = userEvent.setup();
+
+    render(<TrackVersionSelector versions={versions} selectedVersionId={versions[0].id} />);
+
+    const assignBButton = screen.getByRole('button', { name: 'Назначить версию 2 как B' });
+    await user.click(assignBButton);
+
+    const listenBButton = screen.getByRole('button', { name: 'Слушать версию B' });
+    await user.click(listenBButton);
+
+    expect(audioPlayerMocks.switchToVersion).toHaveBeenCalledWith('version-b');
+  });
+});


### PR DESCRIPTION
## Summary
- integrate the track version selector with the shared audio player to allow instant play/pause switching for each option
- surface A/B comparison controls with accessible indicators and keyboard-friendly actions for primary and secondary versions
- add focused unit coverage for the selector, including environment polyfills required by the Radix Select behaviour

## Testing
- npx vitest run src/features/tracks/ui/__tests__/TrackVersionSelector.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e7da7cfb1c832fa6fdb4c8034e57b1