### PR TITLE
Refine workspace layout with modular minimal components

### DIFF
--- a/src/components/layout/ActionTile.tsx
+++ b/src/components/layout/ActionTile.tsx
@@ -1,0 +1,49 @@
+import type { LucideIcon } from "lucide-react";
+import type { MouseEventHandler, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface ActionTileProps {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  actionLabel?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  footer?: ReactNode;
+  className?: string;
+}
+
+export const ActionTile = ({
+  title,
+  description,
+  icon: Icon,
+  actionLabel,
+  onClick,
+  footer,
+  className,
+}: ActionTileProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "flex h-full flex-col items-start gap-3 rounded-lg border border-border/60 bg-card p-4 text-left shadow-sm transition", 
+      "hover:border-primary/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+      className
+    )}
+  >
+    <div className="flex items-center gap-3">
+      <span className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10 text-primary">
+        <Icon className="h-4 w-4" aria-hidden="true" />
+      </span>
+      <span className="text-base font-semibold text-foreground">{title}</span>
+    </div>
+    <p className="text-sm text-muted-foreground">{description}</p>
+    {actionLabel && (
+      <span className="text-sm font-medium text-primary">{actionLabel}</span>
+    )}
+    {footer}
+  </button>
+);
+
+ActionTile.displayName = "ActionTile";
+
+export default ActionTile;

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export const EmptyState = ({
+  title,
+  description,
+  icon,
+  className,
+}: EmptyStateProps) => (
+  <div
+    className={cn(
+      "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/30 p-8 text-center",
+      className
+    )}
+  >
+    {icon && <div className="text-muted-foreground">{icon}</div>}
+    <h3 className="text-base font-semibold text-foreground">{title}</h3>
+    {description && (
+      <p className="text-sm text-muted-foreground">{description}</p>
+    )}
+  </div>
+);
+
+EmptyState.displayName = "EmptyState";
+
+export default EmptyState;

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+const sizeClassMap = {
+  narrow: "max-w-4xl",
+  default: "max-w-6xl",
+  wide: "max-w-7xl",
+} as const;
+
+type ContainerSize = keyof typeof sizeClassMap;
+
+interface PageContainerProps {
+  children: ReactNode;
+  className?: string;
+  size?: ContainerSize;
+}
+
+export const PageContainer = ({
+  children,
+  className,
+  size = "default",
+}: PageContainerProps) => (
+  <div className={cn("w-full", className)}>
+    <div
+      className={cn(
+        "mx-auto w-full px-4 py-6 sm:px-6 lg:px-8",
+        sizeClassMap[size]
+      )}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+PageContainer.displayName = "PageContainer";
+
+export default PageContainer;

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export const PageHeader = ({
+  title,
+  description,
+  icon: Icon,
+  actions,
+  className,
+}: PageHeaderProps) => (
+  <div
+    className={cn(
+      "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between",
+      className
+    )}
+  >
+    <div className="flex items-start gap-3">
+      {Icon && (
+        <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </div>
+      )}
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight sm:text-2xl">
+          {title}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+    </div>
+    {actions && <div className="flex items-center gap-2">{actions}</div>}
+  </div>
+);
+
+PageHeader.displayName = "PageHeader";
+
+export default PageHeader;

--- a/src/components/layout/PageSection.tsx
+++ b/src/components/layout/PageSection.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface PageSectionProps {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export const PageSection = ({
+  title,
+  description,
+  action,
+  children,
+  className,
+  contentClassName,
+}: PageSectionProps) => (
+  <section className={cn("space-y-4", className)}>
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground sm:text-lg">
+          {title}
+        </h2>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {action && <div className="flex items-center gap-2">{action}</div>}
+    </div>
+    <div
+      className={cn(
+        "rounded-lg border border-border/60 bg-card p-4 sm:p-6 shadow-sm",
+        contentClassName
+      )}
+    >
+      {children}
+    </div>
+  </section>
+);
+
+PageSection.displayName = "PageSection";
+
+export default PageSection;

--- a/src/components/layout/StatCard.tsx
+++ b/src/components/layout/StatCard.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface StatCardProps {
+  label: string;
+  value: ReactNode;
+  helperText?: string;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export const StatCard = ({
+  label,
+  value,
+  helperText,
+  icon,
+  className,
+}: StatCardProps) => (
+  <div
+    className={cn(
+      "flex flex-col gap-3 rounded-lg border border-border/60 bg-card p-4 sm:p-5 shadow-sm",
+      className
+    )}
+  >
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-sm font-medium text-muted-foreground">
+        {label}
+      </span>
+      {icon && <span className="text-muted-foreground">{icon}</span>}
+    </div>
+    <div className="text-2xl font-semibold text-foreground sm:text-3xl">
+      {value}
+    </div>
+    {helperText && (
+      <p className="text-xs text-muted-foreground">{helperText}</p>
+    )}
+  </div>
+);
+
+StatCard.displayName = "StatCard";
+
+export default StatCard;

--- a/src/components/navigation/BottomTabBar.tsx
+++ b/src/components/navigation/BottomTabBar.tsx
@@ -1,145 +1,67 @@
-import React, { useCallback } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
-import { 
-  Home, 
-  Sparkles, 
-  Music, 
-  Heart, 
-  Settings,
-  LucideIcon
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useHapticFeedback } from '@/hooks/useHapticFeedback';
-
-interface TabItem {
-  id: string;
-  label: string;
-  icon: LucideIcon;
-  path: string;
-  badge?: number;
-}
-
-const defaultTabs: TabItem[] = [
-  {
-    id: 'dashboard',
-    label: 'Главная',
-    icon: Home,
-    path: '/workspace/dashboard',
-  },
-  {
-    id: 'generate',
-    label: 'Создать',
-    icon: Sparkles,
-    path: '/workspace/generate',
-  },
-  {
-    id: 'library',
-    label: 'Библиотека',
-    icon: Music,
-    path: '/workspace/library',
-  },
-  {
-    id: 'favorites',
-    label: 'Избранное',
-    icon: Heart,
-    path: '/workspace/favorites',
-  },
-  {
-    id: 'settings',
-    label: 'Настройки',
-    icon: Settings,
-    path: '/workspace/settings',
-  },
-];
+import React, { useCallback } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import { useHapticFeedback } from "@/hooks/useHapticFeedback";
+import type { WorkspaceNavItem } from "@/config/workspace-navigation";
 
 interface BottomTabBarProps {
-  tabs?: TabItem[];
+  items: WorkspaceNavItem[];
   className?: string;
 }
 
-export const BottomTabBar: React.FC<BottomTabBarProps> = ({ 
-  tabs = defaultTabs,
-  className 
+export const BottomTabBar: React.FC<BottomTabBarProps> = ({
+  items,
+  className,
 }) => {
   const location = useLocation();
   const { vibrate } = useHapticFeedback();
 
   const handleTabClick = useCallback(() => {
-    vibrate('light');
+    vibrate("light");
   }, [vibrate]);
+
+  if (!items.length) {
+    return null;
+  }
 
   return (
     <nav
       className={cn(
-        'fixed bottom-0 left-0 right-0 z-30',
-        'bg-card/95 backdrop-blur-2xl border-t border-border/30 shadow-2xl',
-        'pb-[env(safe-area-inset-bottom)] pt-2',
-        'lg:hidden',
+        "fixed bottom-0 left-0 right-0 z-30 border-t border-border/60 bg-background/95 backdrop-blur",
+        "pb-[env(safe-area-inset-bottom)]",
+        "lg:hidden",
         className
       )}
       role="navigation"
       aria-label="Основная навигация"
     >
-      <div className="flex items-center justify-around px-2">
-        {tabs.map((tab) => {
-          const isActive = location.pathname === tab.path || 
-                          location.pathname.startsWith(tab.path + '/');
-          const Icon = tab.icon;
+      <div className="flex items-center justify-around px-1">
+        {items.map((item) => {
+          const Icon = item.icon;
+          const isActive =
+            location.pathname === item.path ||
+            location.pathname.startsWith(`${item.path}/`);
 
           return (
             <NavLink
-              key={tab.id}
-              to={tab.path}
+              key={item.id}
+              to={item.path}
               onClick={handleTabClick}
-              className={cn(
-                'flex flex-col items-center justify-center p-2 rounded-xl relative',
-                'min-h-[60px] min-w-[60px] flex-1',
-                'transition-all duration-300 ease-out',
-                'hover:bg-accent/10 active:scale-95',
-                'focus:outline-none focus:ring-2 focus:ring-primary/20',
-                isActive && 'bg-gradient-to-b from-primary/10 to-accent/10 scale-105'
-              )}
-              aria-label={tab.label}
-              aria-current={isActive ? 'page' : undefined}
+              onPointerEnter={() => item.preload?.()}
+              onFocus={() => item.preload?.()}
+              className={({ isActive: navActive }) =>
+                cn(
+                  "flex flex-1 flex-col items-center justify-center gap-1 rounded-md px-3 py-2 text-xs font-medium transition",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+                  "hover:bg-muted/50",
+                  (isActive || navActive) && "text-primary"
+                )
+              }
+              aria-label={item.label}
+              aria-current={isActive ? "page" : undefined}
             >
-              {/* Badge */}
-              {tab.badge && tab.badge > 0 && (
-                <div 
-                  className="absolute -top-0.5 right-2 bg-destructive text-white text-xs rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 font-bold shadow-lg animate-pulse-glow"
-                  aria-label={`${tab.badge} уведомлений`}
-                >
-                  {tab.badge > 99 ? '99+' : tab.badge}
-                </div>
-              )}
-
-              <Icon 
-                className={cn(
-                  'w-6 h-6 mb-1 transition-all duration-300',
-                  isActive 
-                    ? 'text-primary scale-110 drop-shadow-glow' 
-                    : 'text-muted-foreground'
-                )} 
-                strokeWidth={isActive ? 2.5 : 2}
-              />
-              
-              <span 
-                className={cn(
-                  'text-[11px] leading-tight transition-all duration-300',
-                  isActive 
-                    ? 'text-primary font-bold' 
-                    : 'text-muted-foreground font-medium'
-                )}
-              >
-                {tab.label}
-              </span>
-
-              {/* Active Indicator */}
-              {isActive && (
-                <div 
-                  className="absolute -top-0.5 left-1/2 -translate-x-1/2 w-12 h-1 bg-gradient-primary rounded-b-full animate-scale-in shadow-glow-primary"
-                  aria-hidden="true"
-                />
-              )}
+              <Icon className="h-5 w-5" aria-hidden="true" />
+              <span className="text-[11px] leading-tight">{item.label}</span>
             </NavLink>
           );
         })}

--- a/src/components/workspace/MinimalSidebar.tsx
+++ b/src/components/workspace/MinimalSidebar.tsx
@@ -1,191 +1,109 @@
-import { Home, Sparkles, Library, Heart, BarChart3, Settings, User, X, Shield } from "lucide-react";
-import { useNavigate, useLocation } from "react-router-dom";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { X, User, Sparkles } from "lucide-react";
+import { NavLink, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { preloadDashboard, preloadGenerate, preloadLibrary } from '../../utils/lazyImports';
-import { useUserRole } from '@/hooks/useUserRole';
+import type { WorkspaceNavItem } from "@/config/workspace-navigation";
 
 interface MinimalSidebarProps {
   isExpanded: boolean;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
   onClose?: () => void;
+  items: WorkspaceNavItem[];
 }
 
-const MinimalSidebar = ({ isExpanded, onMouseEnter, onMouseLeave, onClose }: MinimalSidebarProps) => {
-  const navigate = useNavigate();
+const baseLinkClasses =
+  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition";
+
+const MinimalSidebar = ({
+  isExpanded,
+  onMouseEnter,
+  onMouseLeave,
+  onClose,
+  items,
+}: MinimalSidebarProps) => {
   const location = useLocation();
-  const { isAdmin } = useUserRole();
-
-  const menuItems = [
-    { 
-      icon: Home, 
-      label: "Главная", 
-      path: "/workspace/dashboard",
-      preload: preloadDashboard
-    },
-    { 
-      icon: Sparkles, 
-      label: "Генерация", 
-      path: "/workspace/generate",
-      preload: preloadGenerate
-    },
-    { 
-      icon: Library, 
-      label: "Библиотека", 
-      path: "/workspace/library",
-      preload: preloadLibrary
-    },
-    { icon: Heart, label: "Избранное", path: "/workspace/favorites" },
-    { icon: BarChart3, label: "Аналитика", path: "/workspace/analytics" },
-    ...(isAdmin ? [{ icon: Shield, label: "Админ-панель", path: "/workspace/admin" }] : []),
-    { icon: Settings, label: "Настройки", path: "/workspace/settings" },
-  ];
-
-  const handleNavigation = (path: string, preload?: () => void) => {
-    navigate(path);
-    preload?.();
-    onClose?.();
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent, path: string, preload?: () => void) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      handleNavigation(path, preload);
-    }
-  };
 
   return (
-    <TooltipProvider>
-      <aside 
-        className={cn(
-          "fixed left-0 top-0 z-40 h-full bg-card/95 backdrop-blur-2xl border-r border-border/50",
-          "flex flex-col items-center py-6 transition-all duration-300 ease-in-out",
-          isExpanded ? "w-64" : "w-16",
-          "hidden lg:flex"
-        )}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        role="navigation"
-        aria-label="Основная навигация"
-      >
-        {/* Close button for mobile */}
+    <aside
+      className={cn(
+        "fixed left-0 top-0 z-40 hidden h-full border-r border-border/60 bg-background/95 backdrop-blur lg:flex",
+        isExpanded ? "w-56" : "w-16"
+      )}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      aria-label="Навигация по рабочему пространству"
+    >
+      <div className="flex w-full flex-col gap-6 px-3 py-6">
         {onClose && (
           <Button
             variant="ghost"
-            size="sm"
+            size="icon"
             onClick={onClose}
-            className="absolute top-4 right-4 lg:hidden w-8 h-8 p-0 hover:bg-accent/10 rounded-xl transition-all duration-300"
+            className="absolute right-2 top-2 h-8 w-8 rounded-md"
             aria-label="Закрыть меню"
           >
-            <X className="w-4 h-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
 
-        {/* Logo/Brand */}
-        <div className="mb-8 p-2 relative group">
-          <div className="absolute inset-0 bg-gradient-primary rounded-2xl blur-lg opacity-40 group-hover:opacity-60 transition-opacity animate-pulse-glow" />
-          <div className="relative w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-accent/20 backdrop-blur-xl border border-primary/20 flex items-center justify-center hover:scale-110 transition-all duration-300">
-            <Sparkles className="w-6 h-6 text-primary" />
+        <div className="flex items-center justify-center">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-card text-primary">
+            <Sparkles className="h-5 w-5" aria-hidden="true" />
           </div>
         </div>
 
-        {/* Navigation Items */}
-        <nav className="flex-1 w-full px-2 space-y-1" role="menubar">
-          {menuItems.map((item) => {
-            const isActive = location.pathname === item.path;
+        <nav className="flex flex-1 flex-col gap-1" role="menubar">
+          {items.map((item) => {
             const Icon = item.icon;
-            
+            const isActive =
+              location.pathname === item.path ||
+              location.pathname.startsWith(`${item.path}/`);
+
             return (
-              <Tooltip key={item.path}>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleNavigation(item.path, item.preload)}
-                    onKeyDown={(e) => handleKeyDown(e, item.path, item.preload)}
-                    className={cn(
-                      "w-full h-12 justify-start px-3 rounded-xl transition-all duration-300 relative group",
-                      isActive 
-                        ? "bg-gradient-to-r from-primary/20 to-accent/20 text-primary border border-primary/20 shadow-glow-primary" 
-                        : "hover:bg-accent/10 hover:scale-105"
-                    )}
-                    role="menuitem"
-                    aria-label={item.label}
-                    aria-current={isActive ? "page" : undefined}
-                    tabIndex={0}
-                  >
-                    <Icon className={cn(
-                      "w-5 h-5 shrink-0 transition-all duration-300",
-                      isActive && "animate-pulse"
-                    )} />
-                    <span className={cn(
-                      "ml-3 whitespace-nowrap transition-all duration-300 font-medium",
-                      isExpanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2"
-                    )}>
-                      {item.label}
-                    </span>
-                    {isActive && (
-                      <div className="absolute right-0 top-1/2 -translate-y-1/2 w-1 h-8 bg-gradient-primary rounded-l-full" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent 
-                  side="right" 
-                  className={cn(
-                    "bg-card/95 backdrop-blur-xl border-border/50",
-                    isExpanded && "hidden"
-                  )}
-                >
-                  <p>{item.label}</p>
-                </TooltipContent>
-              </Tooltip>
+              <NavLink
+                key={item.id}
+                to={item.path}
+                onClick={onClose}
+                onPointerEnter={() => item.preload?.()}
+                onFocus={() => item.preload?.()}
+                title={isExpanded ? undefined : item.label}
+                className={({ isActive: navActive }) =>
+                  cn(
+                    baseLinkClasses,
+                    "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                    !isExpanded && "justify-center px-2",
+                    (isActive || navActive) &&
+                      "bg-primary/10 text-foreground hover:bg-primary/15"
+                  )
+                }
+                role="menuitem"
+                aria-current={isActive ? "page" : undefined}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                {isExpanded && <span className="truncate">{item.label}</span>}
+              </NavLink>
             );
           })}
         </nav>
 
-        {/* User Profile */}
-        <div className="mt-auto p-2 w-full">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full h-12 justify-start px-3 rounded-xl hover:bg-accent/10 transition-all duration-300 hover:scale-105"
-                role="menuitem"
-                aria-label="Профиль пользователя"
-                tabIndex={0}
-              >
-                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 flex items-center justify-center shrink-0">
-                  <User className="w-4 h-4 text-primary" />
-                </div>
-                <span className={cn(
-                  "ml-3 whitespace-nowrap transition-all duration-300 font-medium",
-                  isExpanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2"
-                )}>
-                  Профиль
-                </span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent 
-              side="right" 
-              className={cn(
-                "bg-card/95 backdrop-blur-xl border-border/50",
-                isExpanded && "hidden"
-              )}
-            >
-              <p>Профиль</p>
-            </TooltipContent>
-          </Tooltip>
+        <div className="mt-auto">
+          <button
+            type="button"
+            className={cn(
+              baseLinkClasses,
+              "w-full justify-center border border-border/60 bg-card text-muted-foreground hover:border-border"
+            )}
+            onClick={onClose}
+            aria-label="Открыть профиль"
+            title={isExpanded ? undefined : "Профиль"}
+          >
+            <User className="h-5 w-5" aria-hidden="true" />
+            {isExpanded && <span>Профиль</span>}
+          </button>
         </div>
-      </aside>
-    </TooltipProvider>
+      </div>
+    </aside>
   );
 };
 

--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -1,19 +1,13 @@
 import { Search, Coins } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { NotificationsDropdown } from "./NotificationsDropdown";
 import { UserProfileDropdown } from "./UserProfileDropdown";
 import { Button } from "@/components/ui/button";
 import { useProviderBalance } from "@/hooks/useProviderBalance";
 import { Skeleton } from "@/components/ui/skeleton";
-import { 
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 interface WorkspaceHeaderProps {
   className?: string;
@@ -32,77 +26,50 @@ const WorkspaceHeader = ({ className }: WorkspaceHeaderProps) => {
   return (
     <header
       className={cn(
-        "h-16 border-b border-border/30 bg-background/90 backdrop-blur-2xl flex items-center justify-between px-4 sm:px-6 lg:px-8 shadow-lg",
+        "flex h-16 items-center justify-between border-b border-border/60 bg-background/95 px-4 sm:px-6 lg:px-8 backdrop-blur",
         className
       )}
     >
-      {/* Left Section - Search */}
-      <div className="flex items-center gap-4 flex-1 max-w-2xl">
-        <div className="relative w-full hidden sm:block group">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground/70 group-hover:text-primary/70 transition-colors duration-300" />
+      <div className="flex flex-1 items-center gap-3">
+        <div className="relative hidden w-full max-w-md sm:block">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
           <Input
-            placeholder="Поиск треков, исполнителей..."
-            className="pl-10 h-10 bg-background/50 border-border/50 focus:border-primary/50 focus:ring-2 focus:ring-primary/20 transition-all duration-300 rounded-xl hover:bg-background/70"
+            placeholder="Поиск треков и исполнителей"
+            className="h-10 w-full rounded-md border border-border/60 bg-background pl-9"
           />
         </div>
       </div>
 
-      {/* Right Section - Actions */}
       <div className="flex items-center gap-2 sm:gap-3">
-        {/* Mobile Search */}
         <Button
           variant="ghost"
-          size="sm"
-          className="sm:hidden w-11 h-11 p-0 hover:bg-accent/10 rounded-xl transition-all duration-300"
+          size="icon"
+          className="sm:hidden"
+          aria-label="Открыть поиск"
         >
-          <Search className="w-5 h-5" />
+          <Search className="h-5 w-5" />
         </Button>
 
-        {/* Credits Display */}
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center gap-2 px-3 py-2 bg-accent/10 rounded-xl border border-border/50 hover:bg-accent/20 transition-all duration-300">
-                <Coins className="w-4 h-4 text-primary" />
-                {balanceLoading ? (
-                  <Skeleton className="h-4 w-12" />
-                ) : (
-                  <span className="text-sm font-semibold text-foreground">
-                    {balance?.balance ?? 0}
-                  </span>
-                )}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <div className="space-y-1">
-                <p className="font-semibold">Баланс провайдера: {balance?.provider}</p>
-                <p className="text-xs">Кредитов: {balance?.balance ?? 0}</p>
-                {balance?.plan && <p className="text-xs">План: {balance.plan}</p>}
-                {balance?.monthly_limit && (
-                  <p className="text-xs">Лимит: {balance.monthly_usage ?? 0}/{balance.monthly_limit}</p>
-                )}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <div className="flex items-center gap-2 rounded-md border border-border/60 bg-card px-3 py-1.5 text-sm">
+          <Coins className="h-4 w-4 text-primary" aria-hidden="true" />
+          {balanceLoading ? (
+            <Skeleton className="h-4 w-10" />
+          ) : (
+            <span className="font-medium">{balance?.balance ?? 0}</span>
+          )}
+        </div>
 
-        {/* Notifications Dropdown */}
         <NotificationsDropdown />
 
-        {/* User Profile - Desktop Info + Dropdown */}
-        <div className="flex items-center gap-2 sm:gap-3">
-          <div className="hidden md:flex flex-col items-end min-w-0 max-w-[180px]">
-            <p className="text-sm font-semibold text-foreground truncate w-full">
+        <div className="flex items-center gap-2">
+          <div className="hidden min-w-0 flex-col items-end md:flex">
+            <span className="truncate text-sm font-medium">
               {userEmail.split("@")[0] || "Пользователь"}
-            </p>
-            <p
-              className="text-xs text-muted-foreground truncate w-full overflow-hidden text-ellipsis"
-              title={userEmail}
-            >
+            </span>
+            <span className="truncate text-xs text-muted-foreground" title={userEmail}>
               {userEmail}
-            </p>
+            </span>
           </div>
-          
           <UserProfileDropdown userEmail={userEmail} />
         </div>
       </div>

--- a/src/components/workspace/WorkspaceLayout.tsx
+++ b/src/components/workspace/WorkspaceLayout.tsx
@@ -1,12 +1,19 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Outlet } from "react-router-dom";
 import MinimalSidebar from "./MinimalSidebar";
 import WorkspaceHeader from "./WorkspaceHeader";
 import { BottomTabBar } from "@/components/navigation/BottomTabBar";
 import { cn } from "@/lib/utils";
+import { useUserRole } from "@/hooks/useUserRole";
+import { getWorkspaceNavItems } from "@/config/workspace-navigation";
 
 const WorkspaceLayout = () => {
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false);
+  const { isAdmin } = useUserRole();
+  const navigationItems = useMemo(
+    () => getWorkspaceNavItems({ isAdmin }),
+    [isAdmin]
+  );
 
   return (
     <div className="flex min-h-screen min-h-[100dvh] bg-background">
@@ -15,6 +22,7 @@ const WorkspaceLayout = () => {
         isExpanded={isSidebarExpanded}
         onMouseEnter={() => setIsSidebarExpanded(true)}
         onMouseLeave={() => setIsSidebarExpanded(false)}
+        items={navigationItems}
       />
 
       {/* Main Content */}
@@ -27,13 +35,13 @@ const WorkspaceLayout = () => {
         <WorkspaceHeader className="safe-area-inset lg:block hidden" />
 
         <main
-          className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-[72px] supports-[padding:env(safe-area-inset-bottom)]:pb-[calc(72px+env(safe-area-inset-bottom))] lg:pb-0 bg-gradient-to-br from-background via-background to-accent/5 scrollbar-styled"
+          className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-[72px] supports-[padding:env(safe-area-inset-bottom)]:pb-[calc(72px+env(safe-area-inset-bottom))] lg:pb-0 bg-background scrollbar-styled"
         >
           <Outlet />
         </main>
 
         {/* Bottom Tab Bar - Mobile only */}
-        <BottomTabBar />
+        <BottomTabBar items={navigationItems} />
       </div>
     </div>
   );

--- a/src/config/workspace-navigation.ts
+++ b/src/config/workspace-navigation.ts
@@ -1,0 +1,91 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Home,
+  Sparkles,
+  Library,
+  Heart,
+  BarChart3,
+  Settings,
+  Shield,
+} from "lucide-react";
+import {
+  preloadDashboard,
+  preloadGenerate,
+  preloadLibrary,
+} from "@/utils/lazyImports";
+
+export type WorkspaceNavRole = "admin";
+
+export interface WorkspaceNavItem {
+  id: string;
+  label: string;
+  path: string;
+  icon: LucideIcon;
+  preload?: () => void;
+  roles?: WorkspaceNavRole[];
+}
+
+export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
+  {
+    id: "dashboard",
+    label: "Главная",
+    path: "/workspace/dashboard",
+    icon: Home,
+    preload: preloadDashboard,
+  },
+  {
+    id: "generate",
+    label: "Генерация",
+    path: "/workspace/generate",
+    icon: Sparkles,
+    preload: preloadGenerate,
+  },
+  {
+    id: "library",
+    label: "Библиотека",
+    path: "/workspace/library",
+    icon: Library,
+    preload: preloadLibrary,
+  },
+  {
+    id: "favorites",
+    label: "Избранное",
+    path: "/workspace/favorites",
+    icon: Heart,
+  },
+  {
+    id: "analytics",
+    label: "Аналитика",
+    path: "/workspace/analytics",
+    icon: BarChart3,
+  },
+  {
+    id: "admin",
+    label: "Админ-панель",
+    path: "/workspace/admin",
+    icon: Shield,
+    roles: ["admin"],
+  },
+  {
+    id: "settings",
+    label: "Настройки",
+    path: "/workspace/settings",
+    icon: Settings,
+  },
+];
+
+export const getWorkspaceNavItems = (options?: { isAdmin?: boolean }) => {
+  const { isAdmin } = options ?? {};
+
+  return WORKSPACE_NAV_ITEMS.filter((item) => {
+    if (!item.roles?.length) {
+      return true;
+    }
+
+    if (item.roles.includes("admin")) {
+      return Boolean(isAdmin);
+    }
+
+    return true;
+  });
+};

--- a/src/pages/workspace/Dashboard.tsx
+++ b/src/pages/workspace/Dashboard.tsx
@@ -1,13 +1,18 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Music, Library, Settings, Sparkles, TrendingUp } from "lucide-react";
-import { useNavigate } from "react-router-dom";
 import { useCallback, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Music, Library, Settings, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { TrackCard } from "@/features/tracks";
 import { useToast } from "@/hooks/use-toast";
 import { normalizeTracks } from "@/utils/trackNormalizer";
 import { useDashboardData, DEFAULT_DASHBOARD_STATS } from "@/hooks/useDashboardData";
 import { AnalyticsService } from "@/services/analytics.service";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { PageSection } from "@/components/layout/PageSection";
+import { StatCard } from "@/components/layout/StatCard";
+import { ActionTile } from "@/components/layout/ActionTile";
+import { EmptyState } from "@/components/layout/EmptyState";
 
 const Dashboard = () => {
   const navigate = useNavigate();
@@ -49,160 +54,78 @@ const Dashboard = () => {
   const handleShowAllTracks = useCallback(() => navigate("/workspace/library"), [navigate]);
 
   return (
-    <div className="p-4 md:p-6 space-y-8 animate-fade-in">
-      {/* Welcome Section */}
-      <div className="text-center space-y-4 animate-slide-up">
-        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 animate-float">
-          <Music className="w-8 h-8 text-primary" />
-        </div>
-        <h1 className="text-4xl font-bold text-gradient-primary">
-          Добро пожаловать в MusicAI Pro
-        </h1>
-        <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-          Создавайте невероятную музыку с помощью искусственного интеллекта
-        </p>
-      </div>
+    <PageContainer>
+      <div className="space-y-8">
+        <PageHeader
+          title="Добро пожаловать"
+          description="Создавайте музыку, управляйте проектами и отслеживайте прогресс"
+          icon={Music}
+        />
 
-      {/* Stats Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-scale-in">
-        <Card variant="modern" className="text-center">
-          <CardContent className="p-4">
-            <div className="text-2xl font-bold text-primary">{stats.total}</div>
-            <div className="text-sm text-muted-foreground">Всего треков</div>
-          </CardContent>
-        </Card>
-        
-        <Card variant="modern" className="text-center">
-          <CardContent className="p-4">
-            <div className="text-2xl font-bold text-secondary">{stats.processing}</div>
-            <div className="text-sm text-muted-foreground">В обработке</div>
-          </CardContent>
-        </Card>
-        
-        <Card variant="modern" className="text-center">
-          <CardContent className="p-4">
-            <div className="text-2xl font-bold text-accent">{stats.completed}</div>
-            <div className="text-sm text-muted-foreground">Завершено</div>
-          </CardContent>
-        </Card>
-        
-        <Card variant="modern" className="text-center">
-          <CardContent className="p-4">
-            <div className="text-2xl font-bold text-gradient-secondary">{stats.public}</div>
-            <div className="text-sm text-muted-foreground">Публичных</div>
-          </CardContent>
-        </Card>
-      </div>
+        <section>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <StatCard label="Всего треков" value={stats.total} />
+            <StatCard label="В обработке" value={stats.processing} />
+            <StatCard label="Завершено" value={stats.completed} />
+            <StatCard label="Публичных" value={stats.public} />
+          </div>
+        </section>
 
-      {/* Quick Actions */}
-      <div className="grid md:grid-cols-3 gap-6">
-        <Card 
-          variant="interactive"
-          className="cursor-pointer hover:border-primary/50 transition-all hover-lift animate-scale-in"
-          onClick={handleGenerateClick}
-          style={{ animationDelay: '0.1s' }}
-        >
-          <CardHeader>
-            <div className="w-12 h-12 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center mb-2 animate-pulse-glow">
-              <Sparkles className="w-6 h-6 text-primary" />
-            </div>
-            <CardTitle className="text-gradient-primary">Создать трек</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground text-sm mb-4">
-              Сгенерируйте новую композицию с помощью AI
-            </p>
-            <Button variant="hero" className="w-full">
-              Перейти
-            </Button>
-          </CardContent>
-        </Card>
+        <section>
+          <div className="grid gap-4 md:grid-cols-3">
+            <ActionTile
+              title="Создать трек"
+              description="Сгенерируйте новую композицию при помощи AI"
+              icon={Sparkles}
+              actionLabel="Открыть генератор"
+              onClick={handleGenerateClick}
+            />
+            <ActionTile
+              title="Ваша библиотека"
+              description="Послушайте и управляйте всеми сохранёнными треками"
+              icon={Library}
+              actionLabel="Перейти к библиотеке"
+              onClick={handleLibraryClick}
+            />
+            <ActionTile
+              title="Настройки аккаунта"
+              description="Обновите профиль и параметры рабочей области"
+              icon={Settings}
+              actionLabel="Открыть настройки"
+              onClick={handleSettingsClick}
+            />
+          </div>
+        </section>
 
-        <Card 
-          variant="interactive"
-          className="cursor-pointer hover:border-secondary/50 transition-all hover-lift animate-scale-in"
-          onClick={handleLibraryClick}
-          style={{ animationDelay: '0.2s' }}
-        >
-          <CardHeader>
-            <div className="w-12 h-12 rounded-full bg-gradient-to-br from-secondary/20 to-secondary/10 flex items-center justify-center mb-2">
-              <Library className="w-6 h-6 text-secondary" />
-            </div>
-            <CardTitle className="text-gradient-secondary">Библиотека</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground text-sm mb-4">
-              Просмотрите все ваши треки
-            </p>
-            <Button variant="glow" className="w-full">
-              Перейти
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card 
-          variant="interactive"
-          className="cursor-pointer hover:border-accent/50 transition-all hover-lift animate-scale-in"
-          onClick={handleSettingsClick}
-          style={{ animationDelay: '0.3s' }}
-        >
-          <CardHeader>
-            <div className="w-12 h-12 rounded-full bg-gradient-to-br from-accent/20 to-accent/10 flex items-center justify-center mb-2">
-              <Settings className="w-6 h-6 text-accent" />
-            </div>
-            <CardTitle>Настройки</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground text-sm mb-4">
-              Управляйте вашим аккаунтом
-            </p>
-            <Button variant="modern" className="w-full">
-              Перейти
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Public Tracks Feed */}
-      <Card variant="glass" className="animate-slide-up" style={{ animationDelay: '0.4s' }}>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center gap-2">
-              <TrendingUp className="w-5 h-5 text-primary animate-pulse" />
-              <span className="text-shimmer">Популярные треки</span>
-            </CardTitle>
-            <Button variant="ghost" size="sm" className="hover:text-primary" onClick={handleShowAllTracks}>
+        <PageSection
+          title="Популярные треки"
+          description="Последние публичные релизы сообщества"
+          action={
+            <Button variant="outline" size="sm" onClick={handleShowAllTracks}>
               Показать все
             </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
+          }
+        >
           {isLoading ? (
-            <div className="text-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-              <p className="text-muted-foreground mt-2">Загружаем треки...</p>
+            <div className="flex h-40 items-center justify-center">
+              <span className="text-sm text-muted-foreground">Загружаем треки...</span>
             </div>
           ) : publicTracks.length > 0 ? (
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {publicTracks.map((track, index) => (
-                <div
-                  key={track.id}
-                  className="animate-scale-in"
-                  style={{ animationDelay: `${0.5 + index * 0.1}s` }}
-                >
-                  <TrackCard track={track} />
-                </div>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {publicTracks.map((track) => (
+                <TrackCard key={track.id} track={track} />
               ))}
             </div>
           ) : (
-            <div className="text-center py-8">
-              <Music className="w-12 h-12 text-muted-foreground mx-auto mb-4 opacity-50" />
-              <p className="text-muted-foreground">Пока нет публичных треков</p>
-            </div>
+            <EmptyState
+              title="Пока нет публичных треков"
+              description="Поделитесь своим первым релизом, чтобы он появился здесь"
+              icon={<Music className="h-10 w-10" />}
+            />
           )}
-        </CardContent>
-      </Card>
-    </div>
+        </PageSection>
+      </div>
+    </PageContainer>
   );
 };
 


### PR DESCRIPTION
## Summary
- add shared workspace navigation config and lightweight layout building blocks
- refactor workspace shell, header, and mobile navigation to use the new primitives with a compact aesthetic
- redesign the dashboard page around modular sections, stat cards, and action tiles for better responsiveness

## Testing
- npm run lint *(fails: repository has pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e7f6be43e8832f871c2a80b314cd37