### PR TITLE
Handle missing BottomTabBar items gracefully

### DIFF
--- a/src/components/navigation/BottomTabBar.tsx
+++ b/src/components/navigation/BottomTabBar.tsx
@@ -10,7 +10,7 @@ interface BottomTabBarProps {
 }
 
 export const BottomTabBar: React.FC<BottomTabBarProps> = ({
-  items,
+  items = [],
   className,
 }) => {
   const location = useLocation();


### PR DESCRIPTION
## Summary
- default the BottomTabBar items prop to an empty array so it can render safely even when no items are provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7f8f43850832f90a2099feaad0702