### PR TITLE
Support comma-separated Suno endpoint overrides

### DIFF
--- a/supabase/functions/_shared/suno-balance.ts
+++ b/supabase/functions/_shared/suno-balance.ts
@@ -11,12 +11,16 @@ const unique = (values: Array<string | null | undefined>): string[] => {
   const result: string[] = [];
   for (const value of values) {
     if (!value) continue;
-    const trimmed = value.trim();
-    if (!trimmed) continue;
-    const normalised = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
-    if (!seen.has(normalised)) {
-      seen.add(normalised);
-      result.push(normalised);
+
+    const segments = value.split(",").map((segment) => segment.trim()).filter(Boolean);
+    for (const segment of segments) {
+      if (!segment) continue;
+      const normalised = segment.endsWith("/") ? segment.slice(0, -1) : segment;
+      if (!normalised) continue;
+      if (!seen.has(normalised)) {
+        seen.add(normalised);
+        result.push(normalised);
+      }
     }
   }
   return result;

--- a/supabase/functions/_shared/suno.ts
+++ b/supabase/functions/_shared/suno.ts
@@ -148,12 +148,16 @@ const unique = (values: (string | undefined | null)[]): string[] => {
   const output: string[] = [];
   for (const value of values) {
     if (!value) continue;
-    const normalised = value.trim();
-    if (!normalised) continue;
-    const key = normalised.endsWith("/") ? normalised.slice(0, -1) : normalised;
-    if (!seen.has(key)) {
-      seen.add(key);
-      output.push(key);
+
+    const segments = value.split(",").map((segment) => segment.trim()).filter(Boolean);
+    for (const segment of segments) {
+      if (!segment) continue;
+      const key = segment.endsWith("/") ? segment.slice(0, -1) : segment;
+      if (!key) continue;
+      if (!seen.has(key)) {
+        seen.add(key);
+        output.push(key);
+      }
     }
   }
   return output;

--- a/supabase/functions/_shared/suno_test.ts
+++ b/supabase/functions/_shared/suno_test.ts
@@ -1,0 +1,75 @@
+const assertEquals = (
+  actual: unknown,
+  expected: unknown,
+  message?: string,
+): void => {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(
+      message ??
+        `Assertion failed: expected ${expectedJson} but received ${actualJson}`,
+    );
+  }
+};
+
+Deno.test({
+  name: "comma separated SUNO_GENERATE_URL expands to multiple endpoints",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const original = Deno.env.get("SUNO_GENERATE_URL");
+    Deno.env.set(
+      "SUNO_GENERATE_URL",
+      "https://primary.suno.test/api , https://secondary.suno.test/api/",
+    );
+
+    try {
+      const moduleUrl =
+        new URL(`./suno.ts?split=${crypto.randomUUID()}`, import.meta.url).href;
+      const { createSunoClient } = await import(moduleUrl);
+
+      const attempted: string[] = [];
+      const fetchImpl: typeof fetch = async (input, init) => {
+        const endpoint = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.href
+          : input.url;
+
+        attempted.push(endpoint);
+
+        if (attempted.length < 3) {
+          return new Response(JSON.stringify({ message: "fail" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return new Response(
+          JSON.stringify({ data: { taskId: "task-split" } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      };
+
+      const client = createSunoClient({ apiKey: "test-key", fetchImpl });
+      const result = await client.generateTrack({ prompt: "Test prompt" });
+
+      assertEquals(result.endpoint, "https://api.sunoapi.org/api/v1/generate");
+      assertEquals(attempted, [
+        "https://primary.suno.test/api",
+        "https://secondary.suno.test/api",
+        "https://api.sunoapi.org/api/v1/generate",
+      ]);
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete("SUNO_GENERATE_URL");
+      } else {
+        Deno.env.set("SUNO_GENERATE_URL", original);
+      }
+    }
+  },
+});

--- a/supabase/functions/get-balance/index.ts
+++ b/supabase/functions/get-balance/index.ts
@@ -16,12 +16,16 @@ const unique = (values: Array<string | null | undefined>): string[] => {
   const result: string[] = [];
   for (const value of values) {
     if (!value) continue;
-    const trimmed = value.trim();
-    if (!trimmed) continue;
-    const normalised = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
-    if (!seen.has(normalised)) {
-      seen.add(normalised);
-      result.push(normalised);
+
+    const segments = value.split(",").map((segment) => segment.trim()).filter(Boolean);
+    for (const segment of segments) {
+      if (!segment) continue;
+      const normalised = segment.endsWith('/') ? segment.slice(0, -1) : segment;
+      if (!normalised) continue;
+      if (!seen.has(normalised)) {
+        seen.add(normalised);
+        result.push(normalised);
+      }
     }
   }
   return result;


### PR DESCRIPTION
## Summary
- split comma-separated Suno endpoint overrides before deduping so fallback order is preserved
- apply the same normalization to the balance endpoint helpers used by get-balance
- add a Deno unit test that proves comma-separated overrides expand to multiple generate endpoints

## Testing
- deno test supabase/functions/_shared/suno_test.ts --allow-env --allow-read

------
https://chatgpt.com/codex/tasks/task_e_68e8bcd5c90c832f905151f638c6243f