### PR TITLE
Fix Suno music generation payload handling

### DIFF
--- a/src/services/__tests__/api.service.test.ts
+++ b/src/services/__tests__/api.service.test.ts
@@ -71,11 +71,12 @@ describe("ApiService.generateMusic", () => {
     expect(payload.trackId).toBe(request.trackId);
     // In custom mode, the lyrics are now sent in the 'prompt' field.
     expect(payload.prompt).toBe(request.lyrics);
-    // The 'hasVocals' field is replaced by 'instrumental'.
-    expect(payload.instrumental).toBe(false);
+    expect(payload.lyrics).toBe(request.lyrics);
     expect(payload.customMode).toBe(true);
-    // The 'tags' array is converted to a comma-separated 'style' string.
-    expect(payload.style).toBe(request.styleTags.join(', '));
+    expect(payload.hasVocals).toBe(true);
+    expect(payload.make_instrumental).toBe(false);
+    expect(payload.tags).toEqual(request.styleTags);
+    expect(payload.model_version).toBe(request.modelVersion);
   });
 });
 

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -182,30 +182,47 @@ export class ApiService {
     const provider = request.provider || 'suno';
     const functionName = provider === 'suno' ? 'generate-suno' : 'generate-music';
 
-    // Logic to determine the final prompt based on the new API contract.
-    // In custom mode, lyrics are sent as the main prompt.
-    const promptForSuno = request.customMode ? (request.lyrics || '') : (request.prompt || '');
+    // Normalise user input to match the generate-suno edge function contract.
+    // Custom mode sends lyrics as the main prompt while still providing the
+    // original prompt metadata through Supabase.
+    const normalizedPrompt = request.prompt?.trim() ?? '';
+    const lyrics = request.lyrics;
+    const styleTags = request.styleTags?.filter((tag) => Boolean(tag?.trim())) ?? [];
+    const promptForSuno = request.customMode
+      ? (lyrics ?? normalizedPrompt)
+      : normalizedPrompt;
+    const resolvedTitle = (() => {
+      const explicitTitle = request.title?.trim();
+      if (explicitTitle && explicitTitle.length > 0) {
+        return explicitTitle;
+      }
+      const fallbackSource = normalizedPrompt || lyrics || '';
+      if (fallbackSource) {
+        return fallbackSource.substring(0, 50);
+      }
+      return 'Generated Track';
+    })();
+    const makeInstrumental = request.hasVocals === false;
 
     const payload = {
       trackId: request.trackId,
-      title: request.title || request.prompt.substring(0, 50),
+      title: resolvedTitle,
       prompt: promptForSuno,
-      // The 'tags' array is now a single 'style' string.
-      style: (request.styleTags ?? []).join(', '),
-      // The `instrumental` flag replaces `make_instrumental` and `hasVocals`.
-      instrumental: request.hasVocals === false,
-      // The `model` field replaces `model_version`.
-      model: request.modelVersion || 'V5',
+      tags: styleTags,
+      lyrics,
+      hasVocals: request.hasVocals,
+      make_instrumental: makeInstrumental,
+      model_version: request.modelVersion || 'V5',
       customMode: request.customMode,
     };
 
     logInfo('🎵 [API Service] Selected provider', context, { provider, functionName });
     logDebug('📤 [API Service] Payload summary', context, {
       hasTrackId: Boolean(request.trackId),
-      promptLength: request.prompt.length,
-      tagsCount: request.styleTags?.length ?? 0,
-      hasVocals: request.hasVocals ?? false,
-      lyricsLength: request.lyrics?.length ?? 0,
+      promptLength: normalizedPrompt.length,
+      tagsCount: styleTags.length,
+      hasVocals: typeof request.hasVocals === 'boolean' ? request.hasVocals : null,
+      lyricsLength: lyrics?.length ?? 0,
       customMode: request.customMode ?? null,
     });
 


### PR DESCRIPTION
## Summary
- align the ApiService.generateMusic payload with the generate-suno edge function by sending lyrics, tags, hasVocals, make_instrumental and a safe fallback title
- normalise request logging to avoid undefined prompt metadata
- update the ApiService.generateMusic unit test to reflect the new payload structure

## Testing
- npx vitest run src/services/__tests__/api.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e8d7e67988832faa555d897821e234