### PR TITLE
refactor: compact workspace layout and generator form

### DIFF
--- a/src/components/MusicGenerator.tsx
+++ b/src/components/MusicGenerator.tsx
@@ -469,35 +469,49 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
 
   return (
     <div className="h-full w-full">
-      <Card className="h-full border-border/40 bg-background/95 backdrop-blur-sm shadow-lg">
-        <div className="p-4 border-b border-border/40 bg-muted/20">
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              {balanceLoading ? (
-                <Skeleton className="h-6 w-24" />
-              ) : (
-                <Badge variant="secondary" className="text-xs px-2 py-1">
-                  <Music className="h-3 w-3 mr-1" />
-                  {balance?.balance ?? 0} {balance?.currency ?? 'credits'} · {balance?.provider ?? 'unknown'}
-                </Badge>
-              )}
-            </div>
-
-            <div className="flex items-center gap-2">
+      <Card className="app-panel h-full">
+        <div className="app-panel__header">
+          <div className="app-stack app-stack--tight">
+            <div className="app-inline app-inline--between">
+              <div className="app-stack app-stack--tight">
+                <h2 className="app-panel__heading">Создание трека</h2>
+                <p className="app-panel__description">
+                  Используйте быстрый режим или перейдите в продвинутый для точной настройки.
+                </p>
+              </div>
               <Tabs
                 value={generationMode}
                 onValueChange={handleModeChange}
-                className="w-auto"
+                className="shrink-0"
               >
-                <TabsList className="h-9 p-1 bg-background/50">
-                  <TabsTrigger value="simple" className="text-xs px-3">Simple</TabsTrigger>
-                  <TabsTrigger value="custom" className="text-xs px-3">Custom</TabsTrigger>
+                <TabsList className="app-mode-toggle">
+                  <TabsTrigger value="simple" className="app-mode-toggle__item">Простой</TabsTrigger>
+                  <TabsTrigger value="custom" className="app-mode-toggle__item">Продвинутый</TabsTrigger>
                 </TabsList>
               </Tabs>
+            </div>
+
+            <div className="app-inline app-inline--between">
+              <div className="flex items-center">
+                {balanceLoading ? (
+                  <Skeleton className="h-5 w-24 rounded-full" />
+                ) : (
+                  <Badge
+                    variant="secondary"
+                    className="app-chip bg-background/70 text-[11px] font-medium"
+                  >
+                    <Music className="h-3 w-3" />
+                    <span>
+                      {balance?.balance ?? 0} {balance?.currency ?? 'credits'}
+                    </span>
+                    <span className="hidden sm:inline text-muted-foreground">· {balance?.provider ?? 'unknown'}</span>
+                  </Badge>
+                )}
+              </div>
 
               <Select value={selectedModel} onValueChange={setSelectedModel}>
-                <SelectTrigger className="h-9 w-[120px] text-xs bg-background/50">
-                  <SelectValue />
+                <SelectTrigger className="h-9 w-[160px] text-xs bg-background/60">
+                  <SelectValue placeholder="Модель" />
                 </SelectTrigger>
                 <SelectContent>
                   {modelVersions.map((model) => (
@@ -511,10 +525,10 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
           </div>
         </div>
 
-        <ScrollArea className="h-[calc(100%-80px)]">
-          <div className="p-4 space-y-4">
-            <div className="space-y-2">
-              <Label className="text-sm font-medium flex items-center gap-2">
+        <ScrollArea className="app-panel__scroll">
+          <div className="app-panel__body app-stack">
+            <div className="app-fieldset">
+              <Label className="app-fieldset__label">
                 <FileText className="h-4 w-4" />
                 Заголовок (опционально)
               </Label>
@@ -522,24 +536,24 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                 placeholder="Введите название трека"
                 value={songTitle}
                 onChange={(event) => setSongTitle(event.target.value)}
-                className="h-9 bg-background/50 text-sm"
+                className="h-9 bg-background/60 text-sm"
                 disabled={isGenerating}
               />
-              <p className="text-xs text-muted-foreground">
-                Если поле оставить пустым, мы подберём название автоматически.
+              <p className="app-fieldset__description">
+                Можно оставить пустым — название придумаем автоматически.
               </p>
             </div>
 
             {generationMode === 'simple' ? (
-              <div className="space-y-4 animate-fade-in">
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <Label className="text-sm font-medium">Опишите будущий трек</Label>
+              <div className="app-stack animate-fade-in">
+                <div className="app-fieldset">
+                  <div className="app-inline app-inline--between">
+                    <Label className="app-fieldset__label">Опишите будущий трек</Label>
                     <div className="flex items-center gap-2">
                       <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
-                        className="h-7 text-xs gap-1"
+                        className="h-8 px-3 text-xs gap-1"
                         onClick={() => handleRandomizePrompt('simple')}
                         disabled={isGenerating}
                       >
@@ -547,9 +561,9 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                         Рандом
                       </Button>
                       <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
-                        className="h-7 text-xs gap-1"
+                        className="h-8 px-3 text-xs gap-1"
                         onClick={() => handleEnhancePrompt('simple')}
                         disabled={isImproving || isGenerating}
                       >
@@ -566,20 +580,35 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                     placeholder="Опишите желаемую музыку, настроение и ключевые инструменты"
                     value={simplePrompt}
                     onChange={(event) => setSimplePrompt(event.target.value)}
-                    className="min-h-[120px] resize-none bg-background/50 text-sm"
+                    className="min-h-[96px] resize-none bg-background/60 text-sm"
                     disabled={isGenerating}
                   />
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    {simplePromptExamples.slice(0, 3).map((example) => (
+                      <Button
+                        key={example}
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-3 text-xs"
+                        onClick={() => setSimplePrompt(example)}
+                        disabled={isGenerating}
+                      >
+                        {example}
+                      </Button>
+                    ))}
+                  </div>
                 </div>
 
-                <div className="flex flex-wrap items-center justify-between gap-3 border rounded-lg border-dashed border-border/60 p-3 bg-muted/10">
-                  <div className="flex items-center gap-2">
+                <div className="app-inline-card">
+                  <div className="app-inline">
                     <Switch
                       id="simple-instrumental"
                       checked={simpleInstrumental}
                       onCheckedChange={(checked) => setSimpleInstrumental(Boolean(checked))}
                       disabled={isGenerating}
                     />
-                    <Label htmlFor="simple-instrumental" className="text-sm flex items-center gap-2">
+                    <Label htmlFor="simple-instrumental" className="app-fieldset__label">
                       <Music className="h-4 w-4" />
                       Сделать инструментал
                     </Label>
@@ -589,7 +618,7 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                     type="button"
                     variant="outline"
                     size="sm"
-                    className="h-8 text-xs gap-2"
+                    className="h-8 px-3 text-xs gap-2"
                     onClick={handleAddLyricsFromSimple}
                     disabled={isGenerating}
                   >
@@ -599,27 +628,27 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                 </div>
               </div>
             ) : (
-              <div className="space-y-4 animate-fade-in">
+              <div className="app-stack animate-fade-in">
                 <Accordion
                   type="multiple"
                   value={openBlocks}
                   onValueChange={(value) => setOpenBlocks(Array.isArray(value) ? value : [value])}
-                  className="space-y-2"
+                  className="app-stack app-stack--tight"
                 >
-                  <AccordionItem value="lyrics" className="border-border/40">
-                    <AccordionTrigger className="text-sm font-medium">
+                  <AccordionItem value="lyrics" className="app-subsection border-none">
+                    <AccordionTrigger className="app-subsection__header hover:no-underline">
                       <div className="flex items-center gap-2">
                         <Mic2 className="h-4 w-4" />
                         Лирика
                       </div>
                     </AccordionTrigger>
-                    <AccordionContent className="space-y-2 pt-2">
+                    <AccordionContent className="app-subsection__body">
                       <Textarea
                         ref={lyricsRef}
                         placeholder="Напишите или вставьте текст песни"
                         value={lyrics}
                         onChange={(event) => setLyrics(event.target.value)}
-                        className="min-h-[160px] resize-none bg-background/50 text-sm"
+                        className="min-h-[150px] resize-none bg-background/60 text-sm"
                         disabled={isGenerating}
                       />
                       <div className="flex items-center justify-between text-xs text-muted-foreground">
@@ -629,19 +658,19 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                     </AccordionContent>
                   </AccordionItem>
 
-                  <AccordionItem value="style" className="border-border/40">
-                    <AccordionTrigger className="text-sm font-medium">
+                  <AccordionItem value="style" className="app-subsection border-none">
+                    <AccordionTrigger className="app-subsection__header hover:no-underline">
                       <div className="flex items-center gap-2">
                         <FileText className="h-4 w-4" />
                         Стилевой промт
                       </div>
                     </AccordionTrigger>
-                    <AccordionContent className="space-y-2 pt-2">
-                      <div className="flex items-center justify-end gap-2">
+                    <AccordionContent className="app-subsection__body">
+                      <div className="flex flex-wrap justify-end gap-2">
                         <Button
-                          variant="ghost"
+                          variant="outline"
                           size="sm"
-                          className="h-7 text-xs gap-1"
+                          className="h-8 px-3 text-xs gap-1"
                           onClick={() => handleRandomizePrompt('custom')}
                           disabled={isGenerating}
                         >
@@ -649,9 +678,9 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                           Рандом
                         </Button>
                         <Button
-                          variant="ghost"
+                          variant="outline"
                           size="sm"
-                          className="h-7 text-xs gap-1"
+                          className="h-8 px-3 text-xs gap-1"
                           onClick={() => handleEnhancePrompt('custom')}
                           disabled={isImproving || isGenerating}
                         >
@@ -668,29 +697,29 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                         placeholder="Опишите стиль, атмосферу, референсы"
                         value={customStylePrompt}
                         onChange={(event) => setCustomStylePrompt(event.target.value)}
-                        className="min-h-[160px] resize-none bg-background/50 text-sm"
+                        className="min-h-[140px] resize-none bg-background/60 text-sm"
                         disabled={isGenerating}
                       />
 
-                      <div className="space-y-2">
-                        <Label className="text-sm font-medium flex items-center gap-2">
+                      <div className="app-stack app-stack--tight">
+                        <Label className="app-fieldset__label">
                           <Tag className="h-4 w-4" />
                           Жанры и теги
                         </Label>
-                        <div className="flex flex-col gap-2 sm:flex-row">
+                        <div className="flex flex-col gap-app-tight sm:flex-row sm:items-center">
                           <Input
                             placeholder="Например: synthwave, dream pop"
                             value={styleTagInput}
                             onChange={(event) => setStyleTagInput(event.target.value)}
                             onKeyDown={handleStyleTagKeyDown}
-                            className="h-9 bg-background/50 text-sm"
+                            className="h-9 bg-background/60 text-sm"
                             disabled={isGenerating}
                           />
                           <Button
                             type="button"
-                            variant="secondary"
+                            variant="outline"
                             size="sm"
-                            className="sm:w-auto"
+                            className="sm:w-auto h-9 px-3 text-xs"
                             onClick={() => handleAddStyleTag()}
                             disabled={isGenerating || !styleTagInput.trim() || styleTags.length >= MAX_STYLE_TAGS}
                           >
@@ -698,20 +727,24 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                             Добавить
                           </Button>
                         </div>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="app-fieldset__description">
                           Добавьте жанры и ключевые теги, чтобы Suno точнее понял стиль. Максимум {MAX_STYLE_TAGS} тегов.
                         </p>
 
                         {styleTags.length > 0 ? (
                           <div className="flex flex-wrap gap-2">
                             {styleTags.map((tag) => (
-                              <Badge key={tag} variant="secondary" className="gap-1 px-2 py-1 text-xs">
+                              <Badge
+                                key={tag}
+                                variant="secondary"
+                                className="app-chip app-chip--removable gap-1"
+                              >
                                 <Tag className="h-3 w-3" />
                                 {tag}
                                 <button
                                   type="button"
                                   onClick={() => handleRemoveStyleTag(tag)}
-                                  className="rounded-full bg-secondary-foreground/10 p-0.5 hover:bg-secondary-foreground/20 focus:outline-none focus:ring-1 focus:ring-ring"
+                                  className="focus:outline-none"
                                   aria-label={`Удалить тег ${tag}`}
                                   disabled={isGenerating}
                                 >
@@ -721,19 +754,19 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                             ))}
                           </div>
                         ) : (
-                          <p className="text-xs text-muted-foreground">
+                          <p className="app-fieldset__description">
                             Пока теги не выбраны — добавьте хотя бы один, чтобы запустить генерацию.
                           </p>
                         )}
 
-                        <div className="flex flex-wrap gap-1.5">
+                        <div className="flex flex-wrap gap-2">
                           {DEFAULT_STYLE_TAGS.map((tag) => (
                             <Button
                               key={tag}
                               type="button"
                               variant="outline"
                               size="sm"
-                              className="text-xs"
+                              className="h-7 px-3 text-xs"
                               onClick={() => handleAddStyleTag(tag)}
                               disabled={isGenerating || styleTags.length >= MAX_STYLE_TAGS}
                             >
@@ -745,16 +778,16 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                     </AccordionContent>
                   </AccordionItem>
 
-                  <AccordionItem value="advanced" className="border-border/40">
-                    <AccordionTrigger className="text-sm font-medium">
+                  <AccordionItem value="advanced" className="app-subsection border-none">
+                    <AccordionTrigger className="app-subsection__header hover:no-underline">
                       <div className="flex items-center gap-2">
                         <SlidersHorizontal className="h-4 w-4" />
                         Продвинутые настройки
                       </div>
                     </AccordionTrigger>
-                    <AccordionContent className="space-y-4 pt-2">
-                      <div className="space-y-2">
-                        <Label className="text-sm font-medium flex items-center gap-2">
+                    <AccordionContent className="app-subsection__body app-stack">
+                      <div className="app-fieldset">
+                        <Label className="app-fieldset__label">
                           <ListMinus className="h-4 w-4" />
                           Стили, которые нужно исключить
                         </Label>
@@ -762,19 +795,19 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                           placeholder="Например: trap, eurodance"
                           value={excludeStyles}
                           onChange={(event) => setExcludeStyles(event.target.value)}
-                          className="h-9 bg-background/50 text-sm"
+                          className="h-9 bg-background/60 text-sm"
                           disabled={isGenerating}
                         />
                       </div>
 
-                      <div className="space-y-2">
-                        <Label className="text-sm font-medium">Пол вокала</Label>
+                      <div className="app-fieldset">
+                        <Label className="app-fieldset__label">Пол вокала</Label>
                         <Select
                           value={vocalGender}
                           onValueChange={(value: typeof vocalGender) => setVocalGender(value)}
                           disabled={isGenerating}
                         >
-                          <SelectTrigger className="h-9 bg-background/50 text-sm">
+                          <SelectTrigger className="h-9 bg-background/60 text-sm">
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
@@ -787,8 +820,8 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                         </Select>
                       </div>
 
-                      <div className="space-y-2">
-                        <Label className="text-sm font-medium">Weirdness</Label>
+                      <div className="app-fieldset">
+                        <Label className="app-fieldset__label">Weirdness</Label>
                         <Slider
                           min={0}
                           max={100}
@@ -804,8 +837,8 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                         </div>
                       </div>
 
-                      <div className="space-y-2">
-                        <Label className="text-sm font-medium">Style influence</Label>
+                      <div className="app-fieldset">
+                        <Label className="app-fieldset__label">Style influence</Label>
                         <Slider
                           min={0}
                           max={100}
@@ -821,8 +854,8 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                         </div>
                       </div>
 
-                      <div className="space-y-2">
-                        <Label className="text-sm font-medium flex items-center gap-2">
+                      <div className="app-stack app-stack--tight">
+                        <Label className="app-fieldset__label">
                           <Upload className="h-4 w-4" />
                           Аудио-референс
                         </Label>
@@ -835,13 +868,13 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                           disabled={isGenerating}
                         />
                         {audioReference ? (
-                          <div className="flex items-center justify-between rounded-md border bg-background/60 px-3 py-2 text-sm">
+                          <div className="app-inline-card text-sm">
                             <span className="truncate max-w-[220px] sm:max-w-[260px]">{audioReference.name}</span>
                             <Button
                               type="button"
-                              variant="ghost"
+                              variant="outline"
                               size="sm"
-                              className="text-xs"
+                              className="h-8 px-3 text-xs"
                               onClick={handleClearAudioReference}
                               disabled={isGenerating}
                             >
@@ -851,9 +884,9 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                         ) : (
                           <Button
                             type="button"
-                            variant="secondary"
+                            variant="outline"
                             size="sm"
-                            className="text-xs gap-2"
+                            className="h-8 px-3 text-xs gap-2"
                             onClick={() => audioInputRef.current?.click()}
                             disabled={isGenerating}
                           >
@@ -861,13 +894,13 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
                             Добавить референс
                           </Button>
                         )}
-                        <p className="text-xs text-muted-foreground">
+                        <p className="app-fieldset__description">
                           После загрузки появится ползунок влияния. Файл используется только во время генерации.
                         </p>
 
                         {audioReference && (
-                          <div className="space-y-2">
-                            <Label className="text-sm font-medium">Audio influence</Label>
+                          <div className="app-fieldset">
+                            <Label className="app-fieldset__label">Audio influence</Label>
                             <Slider
                               min={0}
                               max={100}
@@ -892,7 +925,7 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
           </div>
         </ScrollArea>
 
-        <div className="p-4 border-t border-border/40 bg-muted/20">
+        <div className="app-panel__footer">
           <Button
             onClick={handleGenerate}
             disabled={isGenerating}
@@ -910,7 +943,7 @@ const MusicGeneratorComponent = ({ onTrackGenerated }: MusicGeneratorProps) => {
               </>
             )}
           </Button>
-          <div className="text-xs text-muted-foreground text-center mt-2">
+          <div className="app-fieldset__description text-center mt-2">
             ⌘/Ctrl + Enter для запуска
           </div>
         </div>

--- a/src/components/TracksList.tsx
+++ b/src/components/TracksList.tsx
@@ -144,23 +144,23 @@ const TracksListComponent = ({
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <LoadingSkeleton width="120px" height="32px" />
-            <LoadingSkeleton width="60px" height="24px" />
+      <div className="app-stack">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <LoadingSkeleton width="96px" height="28px" />
+            <LoadingSkeleton width="56px" height="24px" />
           </div>
-          <LoadingSkeleton width="100px" height="32px" />
+          <LoadingSkeleton width="88px" height="28px" />
         </div>
-        
+
         {viewMode === 'grid' ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="app-grid app-grid--cards">
             {Array.from({ length: 6 }).map((_, i) => (
-              <LoadingSkeleton key={i} variant="rectangular" height="300px" />
+              <LoadingSkeleton key={i} variant="rectangular" height="260px" />
             ))}
           </div>
         ) : (
-          <div className="space-y-2">
+          <div className="app-stack app-stack--tight">
             {Array.from({ length: 8 }).map((_, i) => (
               <LoadingSkeleton key={i} variant="track-item" />
             ))}
@@ -172,24 +172,24 @@ const TracksListComponent = ({
 
   if (tracks.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="p-6 rounded-full bg-gradient-primary/10 mb-6">
-          <Music className="h-16 w-16 text-primary" />
+      <div className="flex flex-col items-center justify-center py-12 text-center gap-4">
+        <div className="p-4 rounded-full bg-gradient-primary/10">
+          <Music className="h-12 w-12 text-primary" />
         </div>
-        <h3 className="text-2xl font-semibold mb-2">Треков пока нет</h3>
-        <p className="text-muted-foreground max-w-md">
-          Создайте свой первый AI-трек прямо сейчас! Опишите желаемую музыку и получите уникальную композицию.
+        <h3 className="text-lg font-semibold">Треков пока нет</h3>
+        <p className="text-sm text-muted-foreground max-w-md">
+          Создайте свой первый AI-трек: опишите настроение и получите готовую композицию через пару минут.
         </p>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <h2 className="text-2xl font-bold">Ваши треки</h2>
-          <Badge variant="outline">
+    <div className="app-stack">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="text-lg font-semibold tracking-tight">Ваши треки</h2>
+          <Badge variant="outline" className="app-chip text-[11px]">
             {tracks.length} {tracks.length === 1 ? "трек" : "треков"}
           </Badge>
         </div>
@@ -197,11 +197,11 @@ const TracksListComponent = ({
       </div>
 
       {viewMode === 'grid' ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        <div className="app-grid app-grid--cards">
           {tracks.map((track) => {
             const typedTrack = track as Track;
             const isStaleTrack = isStale(typedTrack);
-            
+
             return (
               <div key={track.id} className="space-y-3">
                 <div className="relative">
@@ -268,7 +268,7 @@ const TracksListComponent = ({
           })}
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="app-stack app-stack--tight">
           {tracks.map((track) => {
             const typedTrack = track as Track;
             const isStaleTrack = isStale(typedTrack);

--- a/src/features/tracks/ui/DetailPanel.tsx
+++ b/src/features/tracks/ui/DetailPanel.tsx
@@ -315,20 +315,20 @@ export const DetailPanel = ({ track, onClose, onUpdate, onDelete }: DetailPanelP
 
   return (
     <div
-      className="h-full flex flex-col bg-card border-l border-border w-full max-w-full sm:max-w-md lg:max-w-xl xl:max-w-2xl"
+      className="app-panel h-full w-full max-w-full sm:max-w-md lg:max-w-xl xl:max-w-2xl border-l border-border/20"
       role="complementary"
       aria-label="Панель деталей трека"
     >
       {/* Header */}
-      <div className="flex flex-wrap items-start gap-3 justify-between p-3 sm:p-4 border-b border-border bg-background/95 backdrop-blur-sm sticky top-0 z-10">
+      <div className="app-panel__header sticky top-0 z-10 bg-background/95 backdrop-blur">
         <div className="flex items-center gap-3 flex-1 min-w-0">
           <Badge
             variant={track.status === "completed" ? "default" : "secondary"}
-            className="text-xs shrink-0"
+            className="app-chip text-[11px] shrink-0"
           >
             {track.status === "completed" ? "✅ Готов" : "⏳ В процессе"}
           </Badge>
-          <h3 className="font-semibold text-base truncate" title={track.title}>
+          <h3 className="text-base font-semibold truncate" title={track.title}>
             {track.title}
           </h3>
         </div>
@@ -346,10 +346,10 @@ export const DetailPanel = ({ track, onClose, onUpdate, onDelete }: DetailPanelP
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto overscroll-contain pb-[env(safe-area-inset-bottom)]">
+      <div className="flex-1 overflow-auto overscroll-contain pb-[env(safe-area-inset-bottom)] padding-inline-app padding-block-app">
         {/* Cover Art Preview */}
         {track.cover_url && (
-          <div className="p-4">
+          <div className="padding-app-tight">
             <div className="aspect-square max-h-32 sm:max-h-48 overflow-hidden border border-border rounded-xl shadow-lg">
               <img
                 src={track.cover_url}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 /* Импорт системы дизайн-токенов */
 @import './styles/design-tokens.css';
+/* Компактные layout-примитивы */
+@import './styles/layout.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/pages/workspace/Generate.tsx
+++ b/src/pages/workspace/Generate.tsx
@@ -150,11 +150,14 @@ const Generate = () => {
       : 'calc(100vh - 4rem)';
     
     return (
-      <div className="p-4" style={{ height: pageHeight }}>
-        <ResizablePanelGroup direction="horizontal" className="rounded-lg border border-border overflow-hidden h-full">
+      <div className="app-page" style={{ height: pageHeight }}>
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="h-full overflow-hidden rounded-2xl border border-border/15 bg-background/70 backdrop-blur"
+        >
           {/* Create Panel */}
           <ResizablePanel defaultSize={20} minSize={15} maxSize={30}>
-            <div className="h-full overflow-y-auto scrollbar-styled">
+            <div className="h-full overflow-y-auto scrollbar-styled padding-app-tight">
               <MusicGenerator onTrackGenerated={handleTrackGenerated} />
             </div>
           </ResizablePanel>
@@ -163,7 +166,7 @@ const Generate = () => {
 
           {/* Track List */}
           <ResizablePanel defaultSize={selectedTrack ? 50 : 80} minSize={40}>
-            <div className="h-full overflow-y-auto scrollbar-styled">
+            <div className="h-full overflow-y-auto scrollbar-styled padding-app-tight">
               <TracksList
                 tracks={tracks}
                 isLoading={isLoading}
@@ -201,10 +204,13 @@ const Generate = () => {
       : 'calc(100vh - 4rem)';
     
     return (
-      <div className="p-4" style={{ height: pageHeight }}>
-        <ResizablePanelGroup direction="horizontal" className="rounded-lg border border-border overflow-hidden h-full">
+      <div className="app-page" style={{ height: pageHeight }}>
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="h-full overflow-hidden rounded-2xl border border-border/15 bg-background/70 backdrop-blur"
+        >
           <ResizablePanel defaultSize={30} minSize={25} maxSize={40}>
-            <div className="h-full overflow-y-auto scrollbar-styled">
+            <div className="h-full overflow-y-auto scrollbar-styled padding-app-tight">
               <MusicGenerator onTrackGenerated={handleTrackGenerated} />
             </div>
           </ResizablePanel>
@@ -212,7 +218,7 @@ const Generate = () => {
           <ResizableHandle withHandle className="hover:bg-primary/20 transition-colors" />
 
           <ResizablePanel defaultSize={70} minSize={60}>
-            <div className="h-full overflow-y-auto scrollbar-styled">
+            <div className="h-full overflow-y-auto scrollbar-styled padding-app-tight">
               <TracksList
                 tracks={tracks}
                 isLoading={isLoading}
@@ -247,14 +253,14 @@ const Generate = () => {
     : 'calc(env(safe-area-inset-bottom, 0px) + 1rem)';
   
   return (
-    <div className="flex flex-col h-full relative">
+    <div className="app-page flex flex-col h-full relative">
       {/* Track List - Full Screen */}
-      <div 
-        className="flex-1 overflow-y-auto scrollbar-styled p-4 sm:p-5 transition-all duration-300"
+      <div
+        className="flex-1 overflow-y-auto scrollbar-styled padding-inline-app padding-block-app transition-all duration-300"
         style={{ paddingBottom: `calc(${mobilePaddingBottom} + 4rem)` }} // Add extra space for FAB
       >
         {isPolling && (
-          <div className="space-y-4 mb-4">
+          <div className="app-stack app-stack--tight mb-3">
             <Skeleton className="h-24 w-full rounded-lg" />
           </div>
         )}
@@ -284,15 +290,15 @@ const Generate = () => {
             <Plus className="h-6 w-6" />
           </Button>
         </DrawerTrigger>
-        <DrawerContent 
+        <DrawerContent
           className="p-0 z-[55]"
-          style={{ 
-            maxHeight: currentTrack 
-              ? `calc(90vh - ${PLAYER_HEIGHTS.mobile}px - env(safe-area-inset-bottom))` 
+          style={{
+            maxHeight: currentTrack
+              ? `calc(90vh - ${PLAYER_HEIGHTS.mobile}px - env(safe-area-inset-bottom))`
               : '90vh'
           }}
         >
-          <div className="overflow-y-auto scrollbar-styled p-5 sm:p-6 max-w-2xl mx-auto w-full">
+          <div className="overflow-y-auto scrollbar-styled padding-app max-w-2xl mx-auto w-full">
             <MusicGenerator onTrackGenerated={handleTrackGenerated} />
           </div>
         </DrawerContent>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,180 @@
+/*
+ * Layout primitives and density utilities for Albert3 Muse Synth Studio
+ * Provides a compact, adaptive spacing system shared across workspace screens.
+ */
+
+:root {
+  --app-page-padding: clamp(0.75rem, 1.5vw, 1.5rem);
+  --app-panel-padding-x: clamp(0.9rem, 1.4vw, 1.5rem);
+  --app-panel-padding-y: clamp(0.75rem, 1.2vw, 1.25rem);
+  --app-stack-gap: clamp(0.75rem, 1vw, 1.25rem);
+  --app-stack-gap-tight: clamp(0.5rem, 0.8vw, 1rem);
+  --app-stack-gap-wide: clamp(1rem, 1.4vw, 1.75rem);
+  --app-grid-gap: clamp(0.75rem, 1.2vw, 1.5rem);
+}
+
+@media (max-width: 768px) {
+  :root {
+    --app-page-padding: clamp(0.75rem, 2vw, 1.25rem);
+    --app-panel-padding-x: clamp(0.75rem, 2.2vw, 1.25rem);
+    --app-panel-padding-y: clamp(0.65rem, 1.8vw, 1rem);
+    --app-stack-gap: clamp(0.65rem, 1.4vw, 1rem);
+    --app-stack-gap-tight: clamp(0.45rem, 1vw, 0.85rem);
+    --app-grid-gap: clamp(0.65rem, 1.6vw, 1.25rem);
+  }
+}
+
+@layer components {
+  .app-page {
+    @apply w-full h-full box-border;
+    padding: var(--app-page-padding);
+  }
+
+  .app-panel {
+    @apply flex flex-col rounded-xl border border-border/25 bg-background/90 shadow-md;
+    backdrop-filter: saturate(180%) blur(14px);
+  }
+
+  .app-panel__header {
+    @apply border-b border-border/20;
+    padding: var(--app-panel-padding-y) var(--app-panel-padding-x);
+    display: flex;
+    flex-direction: column;
+    gap: var(--app-stack-gap-tight);
+  }
+
+  .app-panel__body {
+    padding: var(--app-panel-padding-y) var(--app-panel-padding-x);
+  }
+
+  .app-panel__scroll {
+    @apply flex-1;
+  }
+
+  .app-panel__footer {
+    @apply border-t border-border/20;
+    padding: var(--app-panel-padding-y) var(--app-panel-padding-x);
+  }
+
+  .app-panel__heading {
+    @apply text-base font-semibold tracking-tight text-foreground;
+  }
+
+  .app-panel__description {
+    @apply text-sm text-muted-foreground;
+  }
+
+  .app-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--app-stack-gap);
+  }
+
+  .app-stack--tight {
+    gap: var(--app-stack-gap-tight);
+  }
+
+  .app-stack--loose {
+    gap: var(--app-stack-gap-wide);
+  }
+
+  .app-inline {
+    @apply flex flex-wrap items-center;
+    gap: var(--app-stack-gap-tight);
+  }
+
+  .app-inline--between {
+    @apply justify-between;
+  }
+
+  .app-grid {
+    display: grid;
+    gap: var(--app-grid-gap);
+  }
+
+  .app-grid--cards {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .app-grid--two {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .app-mode-toggle {
+    @apply inline-flex items-center rounded-full border border-border/30 bg-background/60 p-1 shadow-inner;
+  }
+
+  .app-mode-toggle__item {
+    @apply rounded-full px-3 py-1 text-xs font-medium transition-all data-[state=active]:bg-primary data-[state=active]:text-primary-foreground;
+  }
+
+  .app-fieldset {
+    @apply flex flex-col gap-2;
+  }
+
+  .app-fieldset__label {
+    @apply text-sm font-medium flex items-center gap-2 text-foreground;
+  }
+
+  .app-fieldset__description {
+    @apply text-xs text-muted-foreground;
+  }
+
+  .app-inline-card {
+    @apply flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/30 bg-background/70 px-3 py-2;
+  }
+
+  .app-chip {
+    @apply inline-flex items-center gap-1 rounded-full border border-border/40 bg-background/70 px-2 py-1 text-xs font-medium text-muted-foreground transition-colors;
+  }
+
+  .app-chip--action {
+    @apply cursor-pointer hover:border-primary/40 hover:bg-primary/10 hover:text-primary;
+  }
+
+  .app-chip--removable button {
+    @apply inline-flex h-4 w-4 items-center justify-center rounded-full bg-secondary-foreground/10 text-secondary-foreground/80 transition-colors hover:bg-secondary-foreground/20;
+  }
+
+  .app-subsection {
+    @apply rounded-lg border border-border/25 bg-background/80;
+  }
+
+  .app-subsection__header {
+    @apply flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-foreground;
+  }
+
+  .app-subsection__body {
+    @apply flex flex-col gap-3 px-4 pb-4 pt-1;
+  }
+
+  .app-section-title {
+    @apply text-sm font-semibold text-foreground;
+  }
+}
+
+@layer utilities {
+  .gap-app {
+    gap: var(--app-stack-gap);
+  }
+
+  .gap-app-tight {
+    gap: var(--app-stack-gap-tight);
+  }
+
+  .padding-app {
+    padding: var(--app-panel-padding-y) var(--app-panel-padding-x);
+  }
+
+  .padding-app-tight {
+    padding: calc(var(--app-panel-padding-y) * 0.75) var(--app-panel-padding-x);
+  }
+
+  .padding-inline-app {
+    padding-inline: var(--app-panel-padding-x);
+  }
+
+  .padding-block-app {
+    padding-block: var(--app-panel-padding-y);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce reusable layout utilities for consistent spacing and density and wire them into the global stylesheet
- rebuild the music generator form with compact simple/advanced modes, responsive sections, and lighter advanced controls
- tighten workspace shells (desktop/tablet/mobile), track list presentation, and the detail panel to match the new layout system

## Testing
- `npm run lint` *(fails: repository contains pre-existing lint errors across docs, tests, and supabase functions)*

------
https://chatgpt.com/codex/tasks/task_e_68e8dffbb420832fb1e6aff8b6918978