### PR TITLE
Adjust Suno weight inputs to expect 0-1 values

### DIFF
--- a/src/services/generation/generation.service.ts
+++ b/src/services/generation/generation.service.ts
@@ -110,9 +110,9 @@ export class GenerationService {
       customMode: customMode !== undefined ? customMode : undefined,
       
       vocalGender: vocalGender && vocalGender !== 'any' ? vocalGender : undefined,
-      audioWeight: audioWeight !== undefined ? audioWeight / 100 : undefined,
-      styleWeight: styleWeight !== undefined ? styleWeight / 100 : undefined,
-      weirdnessConstraint: weirdness !== undefined ? weirdness / 100 : undefined,
+      audioWeight: audioWeight !== undefined ? audioWeight : undefined,
+      styleWeight: styleWeight !== undefined ? styleWeight : undefined,
+      weirdnessConstraint: weirdness !== undefined ? weirdness : undefined,
       referenceAudioUrl: referenceAudioUrl || undefined,
       referenceTrackId: referenceTrackId || undefined,
       negativeTags: negativeTags || undefined,


### PR DESCRIPTION
## Summary
- update GenerationService to forward audio/style/weirdness weights directly to Suno without dividing by 100
- confirm existing callers already normalize weight values to 0-1 so no further changes required

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f22fe160f4832f9633c0b1607e3c0c