### PR TITLE
Fix Mureka generation payload field names

### DIFF
--- a/src/services/generation/__tests__/generate-mureka.test.ts
+++ b/src/services/generation/__tests__/generate-mureka.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenerationService, type GenerationRequest } from '../generation.service';
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    functions: {
+      invoke: invokeMock,
+    },
+  },
+}));
+
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('GenerationService.generate (Mureka)', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue({
+      data: { trackId: 'mock-track', message: 'generation started' },
+      error: null,
+    });
+  });
+
+  it('passes styleTags and modelVersion to the Mureka edge function', async () => {
+    const request: GenerationRequest = {
+      provider: 'mureka',
+      prompt: 'Ambient focus music',
+      title: 'Focus Flow',
+      styleTags: ['ambient', 'focus'],
+      modelVersion: 'o1-beta',
+      hasVocals: false,
+      isBGM: true,
+      idempotencyKey: '123e4567-e89b-12d3-a456-426614174000',
+      trackId: 'mock-track',
+    };
+
+    const result = await GenerationService.generate(request);
+
+    expect(result.success).toBe(true);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    const [functionName, options] = invokeMock.mock.calls[0];
+    expect(functionName).toBe('generate-mureka');
+
+    const payload = (options?.body ?? {}) as Record<string, unknown>;
+    expect(payload.styleTags).toEqual(request.styleTags);
+    expect(payload.modelVersion).toBe(request.modelVersion);
+    expect(payload.hasVocals).toBe(false);
+    expect(payload.isBGM).toBe(true);
+    expect(payload.idempotencyKey).toBe(request.idempotencyKey);
+  });
+
+  it('maps legacy tags to styleTags when styleTags are not provided', async () => {
+    const request: GenerationRequest = {
+      provider: 'mureka',
+      prompt: 'Lo-fi beats',
+      tags: ['lofi', 'calm'],
+      modelVersion: 'o1',
+    };
+
+    await GenerationService.generate(request);
+
+    const [, options] = invokeMock.mock.calls[0];
+    const payload = (options?.body ?? {}) as Record<string, unknown>;
+
+    expect(payload.styleTags).toEqual(request.tags);
+    expect(payload.modelVersion).toBe(request.modelVersion);
+  });
+});

--- a/src/services/generation/generation.service.ts
+++ b/src/services/generation/generation.service.ts
@@ -14,13 +14,15 @@ export interface GenerationRequest {
   title?: string;
   lyrics?: string;
   tags?: string[];
-  
+  styleTags?: string[];
+
   // Provider specific
   provider?: MusicProvider;
   modelVersion?: string;
-  
+
   // Advanced options
   hasVocals?: boolean;
+  isBGM?: boolean;
   customMode?: boolean;
   vocalGender?: 'm' | 'f' | 'any';
   
@@ -163,22 +165,29 @@ export class GenerationService {
       title,
       lyrics,
       tags = [],
+      styleTags = [],
       modelVersion = 'auto',
       hasVocals,
       vocalGender,
+      isBGM,
       idempotencyKey,
       trackId,
     } = request;
+
+    const mergedStyleTags = (styleTags.length > 0 ? styleTags : tags).filter(
+      (tag) => typeof tag === 'string' && tag.trim().length > 0
+    );
 
     const payload = {
       trackId,
       prompt,
       title,
       lyrics: lyrics || undefined,
-      tags: tags.length > 0 ? tags : undefined,
-      model: modelVersion,
+      styleTags: mergedStyleTags.length > 0 ? mergedStyleTags : undefined,
+      modelVersion,
       hasVocals: hasVocals !== undefined ? hasVocals : undefined,
       vocalGender: vocalGender && vocalGender !== 'any' ? vocalGender : undefined,
+      isBGM: isBGM !== undefined ? isBGM : undefined,
       idempotencyKey: idempotencyKey || crypto.randomUUID(),
     };
 


### PR DESCRIPTION
## Summary
- update the Mureka generation payload to send `styleTags`, `modelVersion`, and `isBGM` fields expected by the edge function
- add unit coverage ensuring the Supabase invoke call receives the updated payload structure

## Testing
- npx vitest run src/services/generation/__tests__/generate-mureka.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f2308d62ac832fb91ebbb70b5e0f3c