### PR TITLE
Support Mureka provider in legacy generate flow

### DIFF
--- a/src/components/TracksList.tsx
+++ b/src/components/TracksList.tsx
@@ -106,12 +106,17 @@ const TracksListComponent = ({
 
       toast({ title: "Повторная генерация", description: "Запускаем генерацию заново..." });
 
+      const isSupportedProvider =
+        track.provider === 'suno' ||
+        track.provider === 'replicate' ||
+        track.provider === 'mureka';
+
       await ApiService.generateMusic({
         trackId: track.id,
         userId: user.id,
         title: track.title,
         prompt: track.prompt,
-        provider: (track.provider as 'replicate' | 'suno') || 'suno',
+        ...(isSupportedProvider ? { provider: track.provider } : {}),
         lyrics: track.lyrics || undefined,
         hasVocals: track.has_vocals ?? false,
         styleTags: track.style_tags || undefined,

--- a/src/services/__tests__/api.service.test.ts
+++ b/src/services/__tests__/api.service.test.ts
@@ -119,6 +119,40 @@ describe("ApiService.generateMusic", () => {
     expect(payload.vocalGender).toBeUndefined();
     expect(payload.negativeTags).toBeUndefined();
   });
+
+  it("routes Mureka requests to dedicated edge function with normalized payload", async () => {
+    invokeMock.mockResolvedValue({ data: { success: true, trackId: "track-789" }, error: null });
+
+    const request = {
+      trackId: "track-789",
+      prompt: "  Cinematic score  ",
+      title: "",
+      provider: "mureka" as const,
+      lyrics: "Epic chorus",
+      hasVocals: false,
+      styleTags: [" ambient ", ""],
+      modelVersion: "mureka-o1",
+    };
+
+    await ApiService.generateMusic(request);
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const [functionName, options] = invokeMock.mock.calls[0];
+    expect(functionName).toBe("generate-mureka");
+
+    const payload = (options?.body ?? {}) as Record<string, unknown>;
+    expect(payload.trackId).toBe(request.trackId);
+    expect(payload.title).toBe("Cinematic score");
+    expect(payload.prompt).toBe("Cinematic score");
+    expect(payload.lyrics).toBe(request.lyrics);
+    expect(payload.hasVocals).toBe(false);
+    expect(payload.isBGM).toBe(true);
+    expect(payload.modelVersion).toBe(request.modelVersion);
+    expect(payload.styleTags).toEqual(["ambient"]);
+    expect(payload).not.toHaveProperty("tags");
+    expect(payload).not.toHaveProperty("negativeTags");
+    expect(payload).not.toHaveProperty("vocalGender");
+  });
 });
 
 describe("ApiService.getUserTracks", () => {


### PR DESCRIPTION
## Summary
- forward persisted provider information from the tracks list retry flow with a safe fallback
- extend `ApiService.generateMusic` to recognise the `mureka` provider, adjust the payload, and call the dedicated edge function
- cover the Mureka scenario with a unit test to guard the new routing logic

## Testing
- npx vitest run -t "ApiService.generateMusic" src/services/__tests__/api.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f23e441130832f92fbe860174d7010