### PR TITLE
feat: forward extended generation parameters to providers

### DIFF
--- a/src/services/generation/GenerationService.ts
+++ b/src/services/generation/GenerationService.ts
@@ -14,6 +14,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/utils/logger';
 import { generateMusic as routeToProvider } from '@/services/providers/router';
+import type { GenerateOptions } from '@/services/providers/router';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 
 // Re-export unified MusicProvider type
@@ -51,6 +52,7 @@ export interface GenerationRequest {
   // Optional
   customMode?: boolean;
   isBGM?: boolean;
+  idempotencyKey?: string;
 }
 
 export interface GenerationResult {
@@ -249,17 +251,10 @@ export class GenerationService {
       const trackId = await createTrackRecord(user.id, request);
 
       // 4. Подготовка параметров для провайдера
-      const providerParams = {
+      const providerParams: GenerateOptions = {
+        ...request,
         provider: request.provider,
         trackId,
-        title: request.title,
-        prompt: request.prompt,
-        lyrics: request.lyrics,
-        styleTags: request.styleTags,
-        hasVocals: request.hasVocals,
-        modelVersion: request.modelVersion,
-        referenceAudioUrl: request.referenceAudioUrl,
-        isBGM: request.isBGM,
       };
 
       // 5. Вызов провайдера

--- a/src/services/generation/__tests__/GenerationService.test.ts
+++ b/src/services/generation/__tests__/GenerationService.test.ts
@@ -170,6 +170,16 @@ describe('GenerationService - Integration Tests', () => {
         hasVocals: true,
         modelVersion: 'chirp-v3-5',
         customMode: true,
+        makeInstrumental: false,
+        negativeTags: 'no drums',
+        styleWeight: 0.75,
+        lyricsWeight: 0.65,
+        weirdness: 0.2,
+        audioWeight: 0.5,
+        referenceAudioUrl: 'https://example.com/reference.mp3',
+        referenceTrackId: 'ref-track-123',
+        vocalGender: 'f',
+        idempotencyKey: '00000000-0000-0000-0000-000000000001',
       };
 
       const result = await GenerationService.generate(request);
@@ -186,6 +196,17 @@ describe('GenerationService - Integration Tests', () => {
           styleTags: ['orchestral', 'epic'],
           hasVocals: true,
           modelVersion: 'chirp-v3-5',
+          makeInstrumental: false,
+          negativeTags: 'no drums',
+          styleWeight: 0.75,
+          lyricsWeight: 0.65,
+          weirdness: 0.2,
+          audioWeight: 0.5,
+          referenceAudioUrl: 'https://example.com/reference.mp3',
+          referenceTrackId: 'ref-track-123',
+          customMode: true,
+          vocalGender: 'f',
+          idempotencyKey: '00000000-0000-0000-0000-000000000001',
         })
       );
     });

--- a/src/services/providers/adapters/mureka.adapter.ts
+++ b/src/services/providers/adapters/mureka.adapter.ts
@@ -126,13 +126,30 @@ export class MurekaProviderAdapter implements IProviderClient {
   }
 
   private transformToMurekaFormat(params: GenerationParams): any {
+    const sanitizedStyleTags = Array.isArray(params.styleTags)
+      ? params.styleTags.map((tag) => tag?.trim()).filter((tag): tag is string => Boolean(tag))
+      : [];
+    const makeInstrumental =
+      params.makeInstrumental !== undefined ? params.makeInstrumental : params.isBGM === true;
+    const hasVocals =
+      params.hasVocals !== undefined
+        ? params.hasVocals
+        : makeInstrumental !== undefined
+          ? !makeInstrumental
+          : undefined;
+    const isBGM =
+      params.isBGM !== undefined ? params.isBGM : makeInstrumental ? true : undefined;
+
     return {
+      trackId: params.trackId,
+      title: params.title,
       prompt: params.prompt,
       lyrics: params.lyrics,
-      styleTags: params.styleTags,
-      hasVocals: !params.makeInstrumental,
-      isBGM: params.makeInstrumental || false,
+      styleTags: sanitizedStyleTags.length > 0 ? sanitizedStyleTags : undefined,
+      hasVocals,
+      isBGM,
       modelVersion: params.modelVersion,
+      idempotencyKey: params.idempotencyKey,
     };
   }
 

--- a/src/services/providers/adapters/suno.adapter.ts
+++ b/src/services/providers/adapters/suno.adapter.ts
@@ -128,14 +128,41 @@ export class SunoProviderAdapter implements IProviderClient {
   }
 
   private transformToSunoFormat(params: GenerationParams): any {
+    const clampRatio = (value?: number) => {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        return undefined;
+      }
+      return Math.min(Math.max(value, 0), 1);
+    };
+
+    const sanitizedTags = Array.isArray(params.styleTags)
+      ? params.styleTags.map((tag) => tag?.trim()).filter((tag): tag is string => Boolean(tag))
+      : params.style
+        ? [params.style]
+        : [];
+    const negativeTags = params.negativeTags?.trim();
+    const makeInstrumental =
+      params.makeInstrumental !== undefined ? params.makeInstrumental : params.hasVocals === false;
+    const vocalGender = params.vocalGender === 'm' || params.vocalGender === 'f' ? params.vocalGender : undefined;
+
     return {
+      trackId: params.trackId,
       prompt: params.prompt,
       lyrics: params.lyrics,
-      tags: params.styleTags || (params.style ? [params.style] : []),
-      make_instrumental: params.makeInstrumental || false,
+      tags: sanitizedTags,
+      make_instrumental: !!makeInstrumental,
       model_version: params.modelVersion || 'V5',
-      reference_audio_url: params.referenceAudio,
-      reference_track_id: params.referenceTrackId,
+      hasVocals: params.hasVocals,
+      customMode: params.customMode,
+      negativeTags: negativeTags && negativeTags.length > 0 ? negativeTags : undefined,
+      vocalGender,
+      styleWeight: clampRatio(params.styleWeight),
+      lyricsWeight: clampRatio(params.lyricsWeight),
+      weirdnessConstraint: clampRatio(params.weirdness),
+      audioWeight: clampRatio(params.audioWeight),
+      referenceAudioUrl: params.referenceAudio,
+      referenceTrackId: params.referenceTrackId,
+      idempotencyKey: params.idempotencyKey,
     };
   }
 

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -33,6 +33,7 @@ export interface ProviderConfig {
 
 export interface GenerationParams {
   prompt: string;
+  title?: string;
   lyrics?: string;
   duration?: number;
   style?: string;
@@ -42,6 +43,16 @@ export interface GenerationParams {
   hasVocals?: boolean;
   makeInstrumental?: boolean;
   modelVersion?: string;
+  negativeTags?: string;
+  vocalGender?: 'm' | 'f' | 'any';
+  audioWeight?: number;
+  styleWeight?: number;
+  lyricsWeight?: number;
+  weirdness?: number;
+  customMode?: boolean;
+  isBGM?: boolean;
+  idempotencyKey?: string;
+  trackId?: string;
 }
 
 export interface ExtensionParams {


### PR DESCRIPTION
## Summary
- pass the full GenerationRequest payload to the provider router, including advanced weights and metadata
- update the router and provider adapters to serialize extended options for Suno and Mureka edge functions
- refresh GenerationService tests to cover the expanded parameter surface

## Testing
- npx vitest run src/services/generation/__tests__/GenerationService.test.ts src/services/generation/__tests__/error-scenarios.test.ts src/services/generation/__tests__/generate-mureka.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f2479682a8832fa48499876bfdde19