### PR TITLE
Fix default vocal handling in provider routing

### DIFF
--- a/src/services/providers/__tests__/router.test.ts
+++ b/src/services/providers/__tests__/router.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: invokeMock,
+    },
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { generateMusic } from "../router";
+
+const createInvokeResponse = () => ({
+  data: { success: true, taskId: "task-1", trackId: "track-1" },
+  error: null,
+});
+
+describe("Provider router - generateMusic", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("defaults to including vocals when hasVocals is not provided", async () => {
+    invokeMock.mockResolvedValue(createInvokeResponse());
+
+    const result = await generateMusic({
+      provider: "suno",
+      prompt: "Test prompt",
+    });
+
+    expect(result).toEqual({ success: true, taskId: "task-1", trackId: "track-1" });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    const [functionName, options] = invokeMock.mock.calls[0];
+    expect(functionName).toBe("generate-suno");
+
+    const payload = (options?.body ?? {}) as Record<string, unknown>;
+    expect(payload.make_instrumental).toBe(false);
+    expect(payload.hasVocals).toBeUndefined();
+  });
+
+  it("requests an instrumental when hasVocals is explicitly false", async () => {
+    invokeMock.mockResolvedValue(createInvokeResponse());
+
+    await generateMusic({
+      provider: "suno",
+      prompt: "Instrumental please",
+      hasVocals: false,
+    });
+
+    const [, options] = invokeMock.mock.calls[0];
+    const payload = (options?.body ?? {}) as Record<string, unknown>;
+    expect(payload.make_instrumental).toBe(true);
+    expect(payload.hasVocals).toBe(false);
+  });
+});

--- a/src/services/providers/adapters/mureka.adapter.ts
+++ b/src/services/providers/adapters/mureka.adapter.ts
@@ -129,16 +129,15 @@ export class MurekaProviderAdapter implements IProviderClient {
     const sanitizedStyleTags = Array.isArray(params.styleTags)
       ? params.styleTags.map((tag) => tag?.trim()).filter((tag): tag is string => Boolean(tag))
       : [];
+    const resolvedHasVocals =
+      typeof params.hasVocals === 'boolean' ? params.hasVocals : undefined;
     const makeInstrumental =
-      params.makeInstrumental !== undefined ? params.makeInstrumental : params.isBGM === true;
-    const hasVocals =
-      params.hasVocals !== undefined
-        ? params.hasVocals
-        : makeInstrumental !== undefined
-          ? !makeInstrumental
-          : undefined;
+      typeof params.makeInstrumental === 'boolean'
+        ? params.makeInstrumental
+        : resolvedHasVocals === false || params.isBGM === true;
+    const hasVocals = resolvedHasVocals !== undefined ? resolvedHasVocals : !makeInstrumental;
     const isBGM =
-      params.isBGM !== undefined ? params.isBGM : makeInstrumental ? true : undefined;
+      typeof params.isBGM === 'boolean' ? params.isBGM : makeInstrumental ? true : undefined;
 
     return {
       trackId: params.trackId,

--- a/src/services/providers/adapters/suno.adapter.ts
+++ b/src/services/providers/adapters/suno.adapter.ts
@@ -141,8 +141,12 @@ export class SunoProviderAdapter implements IProviderClient {
         ? [params.style]
         : [];
     const negativeTags = params.negativeTags?.trim();
+    const resolvedHasVocals =
+      typeof params.hasVocals === 'boolean' ? params.hasVocals : undefined;
     const makeInstrumental =
-      params.makeInstrumental !== undefined ? params.makeInstrumental : params.hasVocals === false;
+      typeof params.makeInstrumental === 'boolean'
+        ? params.makeInstrumental
+        : resolvedHasVocals === false;
     const vocalGender = params.vocalGender === 'm' || params.vocalGender === 'f' ? params.vocalGender : undefined;
 
     return {
@@ -150,9 +154,9 @@ export class SunoProviderAdapter implements IProviderClient {
       prompt: params.prompt,
       lyrics: params.lyrics,
       tags: sanitizedTags,
-      make_instrumental: !!makeInstrumental,
+      make_instrumental: makeInstrumental,
       model_version: params.modelVersion || 'V5',
-      hasVocals: params.hasVocals,
+      hasVocals: resolvedHasVocals,
       customMode: params.customMode,
       negativeTags: negativeTags && negativeTags.length > 0 ? negativeTags : undefined,
       vocalGender,

--- a/src/services/providers/router.ts
+++ b/src/services/providers/router.ts
@@ -67,10 +67,12 @@ export const generateMusic = async (options: GenerateOptions): Promise<GenerateR
         const trimmedLyrics = lyrics?.trim();
         const effectiveLyrics = trimmedLyrics && trimmedLyrics.length > 0 ? trimmedLyrics : undefined;
         const normalizedPrompt = params.prompt?.trim() || effectiveLyrics || 'Music generation';
+        const resolvedHasVocals =
+          typeof params.hasVocals === 'boolean' ? params.hasVocals : undefined;
         const makeInstrumental =
-          params.makeInstrumental !== undefined
+          typeof params.makeInstrumental === 'boolean'
             ? params.makeInstrumental
-            : params.hasVocals === false;
+            : resolvedHasVocals === false;
         const normalizedVocalGender =
           params.vocalGender === 'm' || params.vocalGender === 'f'
             ? params.vocalGender
@@ -96,8 +98,8 @@ export const generateMusic = async (options: GenerateOptions): Promise<GenerateR
             prompt: normalizedPrompt,
             lyrics: customMode ? effectiveLyrics : undefined,
             tags: sanitizedTags,
-            make_instrumental: !!makeInstrumental,
-            hasVocals: params.hasVocals,
+            make_instrumental: makeInstrumental,
+            hasVocals: resolvedHasVocals,
             customMode,
             model_version: params.modelVersion || 'chirp-v3-5',
             idempotencyKey: params.idempotencyKey,
@@ -120,18 +122,15 @@ export const generateMusic = async (options: GenerateOptions): Promise<GenerateR
         const sanitizedStyleTags = Array.isArray(params.styleTags)
           ? params.styleTags.map((tag) => tag?.trim()).filter((tag): tag is string => Boolean(tag))
           : [];
+        const resolvedHasVocals =
+          typeof params.hasVocals === 'boolean' ? params.hasVocals : undefined;
         const makeInstrumental =
-          params.makeInstrumental !== undefined
+          typeof params.makeInstrumental === 'boolean'
             ? params.makeInstrumental
-            : params.hasVocals === false || params.isBGM === true;
-        const hasVocals =
-          params.hasVocals !== undefined
-            ? params.hasVocals
-            : makeInstrumental !== undefined
-              ? !makeInstrumental
-              : undefined;
+            : resolvedHasVocals === false || params.isBGM === true;
+        const hasVocals = resolvedHasVocals !== undefined ? resolvedHasVocals : !makeInstrumental;
         const isBGM =
-          params.isBGM !== undefined ? params.isBGM : makeInstrumental ? true : undefined;
+          typeof params.isBGM === 'boolean' ? params.isBGM : makeInstrumental ? true : undefined;
 
         const { data, error } = await supabase.functions.invoke('generate-mureka', {
           body: {


### PR DESCRIPTION
## Summary
- ensure the provider router defaults to vocal tracks unless `hasVocals` is explicitly `false`
- align Suno and Mureka adapters with the safer `hasVocals === false` check to avoid unintended instrumentals
- add unit tests covering generation requests without the `hasVocals` flag and explicit instrumental requests

## Testing
- npx vitest run src/services/providers/__tests__/router.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68f24afc8ed8832fa874c96d1e183662