### PR TITLE
feat: add prompt usage increment rpc

### DIFF
--- a/src/hooks/usePromptHistory.ts
+++ b/src/hooks/usePromptHistory.ts
@@ -104,20 +104,9 @@ export const usePromptHistory = () => {
   // Update usage
   const updateUsage = useMutation({
     mutationFn: async (id: string) => {
-      // First fetch current usage_count
-      const { data: current } = await supabase
-        .from('prompt_history')
-        .select('usage_count')
-        .eq('id', id)
-        .single();
-      
-      const { error } = await supabase
-        .from('prompt_history')
-        .update({
-          usage_count: (current?.usage_count || 0) + 1,
-          last_used_at: new Date().toISOString(),
-        })
-        .eq('id', id);
+      const { error } = await supabase.rpc('increment_prompt_usage', {
+        p_prompt_id: id,
+      });
 
       if (error) throw error;
     },

--- a/supabase/migrations/20251018090000_add_increment_prompt_usage_function.sql
+++ b/supabase/migrations/20251018090000_add_increment_prompt_usage_function.sql
@@ -1,0 +1,17 @@
+-- Create RPC function for atomic usage increment
+create or replace function public.increment_prompt_usage(p_prompt_id uuid)
+returns prompt_history
+language sql
+security invoker
+set search_path = public
+as $$
+  update public.prompt_history
+     set usage_count = coalesce(usage_count, 0) + 1,
+         last_used_at = now()
+   where id = p_prompt_id
+   returning prompt_history.*;
+$$;
+
+-- Allow authenticated and service role clients to execute the function
+grant execute on function public.increment_prompt_usage(uuid) to authenticated;
+grant execute on function public.increment_prompt_usage(uuid) to service_role;


### PR DESCRIPTION
## Summary
- add a Supabase RPC to atomically increment prompt usage counters
- update the prompt history hook to call the new RPC instead of issuing multiple queries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f24db3500c832f8e01965de38b8483