### PR TITLE
Propagate advanced generation parameters through provider pipeline

### DIFF
--- a/src/services/generation/GenerationService.ts
+++ b/src/services/generation/GenerationService.ts
@@ -26,28 +26,28 @@ export interface GenerationRequest {
   title?: string;
   prompt: string;
   provider: import('@/config/provider-models').MusicProvider;
-  
+
   // Music params
   lyrics?: string;
   styleTags?: string[];
   hasVocals?: boolean;
   makeInstrumental?: boolean;
-  
+
   // Advanced params
   modelVersion?: string;
   negativeTags?: string;
   vocalGender?: 'm' | 'f' | 'any';
-  
+
   // Audio reference
   referenceAudioUrl?: string;
   referenceTrackId?: string;
   audioWeight?: number;
-  
+
   // Weights & constraints
   styleWeight?: number;
   lyricsWeight?: number;
   weirdness?: number;
-  
+
   // Optional
   customMode?: boolean;
   isBGM?: boolean;
@@ -250,6 +250,7 @@ export class GenerationService {
 
       // 4. Подготовка параметров для провайдера
       const providerParams = {
+        ...request,
         provider: request.provider,
         trackId,
         title: request.title,
@@ -257,8 +258,17 @@ export class GenerationService {
         lyrics: request.lyrics,
         styleTags: request.styleTags,
         hasVocals: request.hasVocals,
+        makeInstrumental: request.makeInstrumental,
         modelVersion: request.modelVersion,
+        negativeTags: request.negativeTags,
+        vocalGender: request.vocalGender,
         referenceAudioUrl: request.referenceAudioUrl,
+        referenceTrackId: request.referenceTrackId,
+        audioWeight: request.audioWeight,
+        styleWeight: request.styleWeight,
+        lyricsWeight: request.lyricsWeight,
+        weirdness: request.weirdness,
+        customMode: request.customMode,
         isBGM: request.isBGM,
       };
 

--- a/src/services/generation/__tests__/GenerationService.test.ts
+++ b/src/services/generation/__tests__/GenerationService.test.ts
@@ -168,8 +168,17 @@ describe('GenerationService - Integration Tests', () => {
         provider: 'suno',
         styleTags: ['orchestral', 'epic'],
         hasVocals: true,
+        makeInstrumental: false,
         modelVersion: 'chirp-v3-5',
         customMode: true,
+        negativeTags: 'dissonant',
+        styleWeight: 0.75,
+        lyricsWeight: 0.65,
+        weirdness: 0.3,
+        audioWeight: 0.2,
+        referenceAudioUrl: 'https://example.com/ref.mp3',
+        referenceTrackId: 'ref-track-123',
+        vocalGender: 'f',
       };
 
       const result = await GenerationService.generate(request);
@@ -185,7 +194,17 @@ describe('GenerationService - Integration Tests', () => {
           lyrics: 'Verse 1\nChorus\nVerse 2',
           styleTags: ['orchestral', 'epic'],
           hasVocals: true,
+          makeInstrumental: false,
           modelVersion: 'chirp-v3-5',
+          customMode: true,
+          negativeTags: 'dissonant',
+          styleWeight: 0.75,
+          lyricsWeight: 0.65,
+          weirdness: 0.3,
+          audioWeight: 0.2,
+          referenceAudioUrl: 'https://example.com/ref.mp3',
+          referenceTrackId: 'ref-track-123',
+          vocalGender: 'f',
         })
       );
     });

--- a/src/services/generation/__tests__/generate-mureka.test.ts
+++ b/src/services/generation/__tests__/generate-mureka.test.ts
@@ -40,6 +40,16 @@ describe('GenerationService.generate (Mureka)', () => {
       modelVersion: 'o1-beta',
       hasVocals: false,
       isBGM: true,
+      makeInstrumental: true,
+      customMode: false,
+      negativeTags: 'no drums',
+      audioWeight: 0.4,
+      styleWeight: 0.6,
+      lyricsWeight: 0.2,
+      weirdness: 0.1,
+      referenceAudioUrl: 'https://cdn.example.com/sample.wav',
+      referenceTrackId: 'ref-987',
+      vocalGender: 'any',
       idempotencyKey: '123e4567-e89b-12d3-a456-426614174000',
       trackId: 'mock-track',
     };
@@ -58,6 +68,16 @@ describe('GenerationService.generate (Mureka)', () => {
     expect(payload.hasVocals).toBe(false);
     expect(payload.isBGM).toBe(true);
     expect(payload.idempotencyKey).toBe(request.idempotencyKey);
+    expect(payload.makeInstrumental).toBe(true);
+    expect(payload.customMode).toBe(false);
+    expect(payload.negativeTags).toBe('no drums');
+    expect(payload.audioWeight).toBe(0.4);
+    expect(payload.styleWeight).toBe(0.6);
+    expect(payload.lyricsWeight).toBe(0.2);
+    expect(payload.weirdness).toBe(0.1);
+    expect(payload.referenceAudioUrl).toBe('https://cdn.example.com/sample.wav');
+    expect(payload.referenceTrackId).toBe('ref-987');
+    expect(payload.vocalGender).toBe('any');
   });
 
   it('maps legacy tags to styleTags when styleTags are not provided', async () => {

--- a/src/services/generation/generation.service.ts
+++ b/src/services/generation/generation.service.ts
@@ -99,28 +99,32 @@ export class GenerationService {
     // Map parameters to Suno API format
     const payload = {
       trackId,
-      
+
       // ✅ CRITICAL: Prompt vs Lyrics разделение
       prompt: customMode ? undefined : prompt,  // В simple mode - описание стиля
       lyrics: customMode ? (lyrics || prompt) : undefined,  // В custom mode - текст песни
-      
+
       title,
       tags: tags.length > 0 ? tags : undefined,
       model_version: modelVersion,
-      
+
       hasVocals: hasVocals !== undefined ? hasVocals : undefined,
+      make_instrumental: request.makeInstrumental ?? hasVocals === false,
+      makeInstrumental: request.makeInstrumental,
       customMode: customMode !== undefined ? customMode : undefined,
-      
-      vocalGender: vocalGender && vocalGender !== 'any' ? vocalGender : undefined,
+
+      vocalGender: vocalGender ?? undefined,
       audioWeight: audioWeight !== undefined ? audioWeight : undefined,
       styleWeight: styleWeight !== undefined ? styleWeight : undefined,
+      lyricsWeight: request.lyricsWeight !== undefined ? request.lyricsWeight : undefined,
       weirdnessConstraint: weirdness !== undefined ? weirdness : undefined,
+      weirdness: weirdness !== undefined ? weirdness : undefined,
       referenceAudioUrl: referenceAudioUrl || undefined,
       referenceTrackId: referenceTrackId || undefined,
       negativeTags: negativeTags || undefined,
       idempotencyKey: idempotencyKey || crypto.randomUUID(),
-      make_instrumental: hasVocals === false,
       wait_audio: false,
+      isBGM: request.isBGM,
     };
 
     logger.info('📤 [GenerationService] Calling Suno edge function', 'GenerationService', {
@@ -186,9 +190,18 @@ export class GenerationService {
       styleTags: mergedStyleTags.length > 0 ? mergedStyleTags : undefined,
       modelVersion,
       hasVocals: hasVocals !== undefined ? hasVocals : undefined,
-      vocalGender: vocalGender && vocalGender !== 'any' ? vocalGender : undefined,
+      vocalGender: vocalGender ?? undefined,
       isBGM: isBGM !== undefined ? isBGM : undefined,
       idempotencyKey: idempotencyKey || crypto.randomUUID(),
+      makeInstrumental: request.makeInstrumental,
+      customMode: request.customMode,
+      negativeTags: request.negativeTags,
+      audioWeight: request.audioWeight,
+      styleWeight: request.styleWeight,
+      lyricsWeight: request.lyricsWeight,
+      weirdness: request.weirdness,
+      referenceAudioUrl: request.referenceAudioUrl,
+      referenceTrackId: request.referenceTrackId,
     };
 
     logger.info('📤 [GenerationService] Calling Mureka edge function', 'GenerationService');

--- a/src/services/providers/adapters/mureka.adapter.ts
+++ b/src/services/providers/adapters/mureka.adapter.ts
@@ -130,9 +130,19 @@ export class MurekaProviderAdapter implements IProviderClient {
       prompt: params.prompt,
       lyrics: params.lyrics,
       styleTags: params.styleTags,
-      hasVocals: !params.makeInstrumental,
-      isBGM: params.makeInstrumental || false,
+      hasVocals: params.hasVocals ?? !params.makeInstrumental,
+      isBGM: params.isBGM ?? params.makeInstrumental || false,
+      makeInstrumental: params.makeInstrumental,
       modelVersion: params.modelVersion,
+      customMode: params.customMode,
+      negativeTags: params.negativeTags,
+      audioWeight: params.audioWeight,
+      styleWeight: params.styleWeight,
+      lyricsWeight: params.lyricsWeight,
+      weirdness: params.weirdness,
+      referenceAudioUrl: params.referenceAudio,
+      referenceTrackId: params.referenceTrackId,
+      vocalGender: params.vocalGender,
     };
   }
 

--- a/src/services/providers/adapters/suno.adapter.ts
+++ b/src/services/providers/adapters/suno.adapter.ts
@@ -132,10 +132,22 @@ export class SunoProviderAdapter implements IProviderClient {
       prompt: params.prompt,
       lyrics: params.lyrics,
       tags: params.styleTags || (params.style ? [params.style] : []),
-      make_instrumental: params.makeInstrumental || false,
+      make_instrumental: params.makeInstrumental ?? params.hasVocals === false,
+      hasVocals: params.hasVocals,
+      customMode: params.customMode,
       model_version: params.modelVersion || 'V5',
+      negativeTags: params.negativeTags,
+      styleWeight: params.styleWeight,
+      lyricsWeight: params.lyricsWeight,
+      weirdness: params.weirdness,
+      audioWeight: params.audioWeight,
+      referenceAudioUrl: params.referenceAudio,
       reference_audio_url: params.referenceAudio,
+      referenceTrackId: params.referenceTrackId,
       reference_track_id: params.referenceTrackId,
+      vocalGender: params.vocalGender,
+      isBGM: params.isBGM,
+      audioPrompt: params.audioPrompt,
     };
   }
 

--- a/src/services/providers/router.ts
+++ b/src/services/providers/router.ts
@@ -17,10 +17,20 @@ export interface GenerateOptions {
   lyrics?: string;
   styleTags?: string[];
   hasVocals?: boolean;
+  makeInstrumental?: boolean;
   modelVersion?: string;
   idempotencyKey?: string;
   referenceAudioUrl?: string;
+  referenceTrackId?: string;
+  audioWeight?: number;
+  styleWeight?: number;
+  lyricsWeight?: number;
+  weirdness?: number;
+  negativeTags?: string;
+  vocalGender?: 'm' | 'f' | 'any';
+  customMode?: boolean;
   isBGM?: boolean;
+  audioPrompt?: string;
 }
 
 export interface ProviderBalance {
@@ -54,12 +64,21 @@ export const generateMusic = async (options: GenerateOptions): Promise<GenerateR
             prompt: params.prompt || params.lyrics || 'Music generation',
             lyrics: params.lyrics,
             tags: params.styleTags || [],
-            make_instrumental: !params.hasVocals,
+            make_instrumental: params.makeInstrumental ?? !params.hasVocals,
             hasVocals: params.hasVocals,
-            customMode: !!params.lyrics,
+            customMode: params.customMode ?? !!params.lyrics,
             model_version: params.modelVersion || 'chirp-v3-5',
             idempotencyKey: params.idempotencyKey,
             referenceAudioUrl: params.referenceAudioUrl,
+            referenceTrackId: params.referenceTrackId,
+            audioWeight: params.audioWeight,
+            styleWeight: params.styleWeight,
+            lyricsWeight: params.lyricsWeight,
+            weirdness: params.weirdness,
+            negativeTags: params.negativeTags,
+            vocalGender: params.vocalGender,
+            isBGM: params.isBGM,
+            audioPrompt: params.audioPrompt,
           },
         });
 
@@ -79,6 +98,16 @@ export const generateMusic = async (options: GenerateOptions): Promise<GenerateR
             isBGM: params.isBGM,
             modelVersion: params.modelVersion || 'auto',
             idempotencyKey: params.idempotencyKey,
+            makeInstrumental: params.makeInstrumental,
+            customMode: params.customMode,
+            negativeTags: params.negativeTags,
+            audioWeight: params.audioWeight,
+            styleWeight: params.styleWeight,
+            lyricsWeight: params.lyricsWeight,
+            weirdness: params.weirdness,
+            referenceAudioUrl: params.referenceAudioUrl,
+            referenceTrackId: params.referenceTrackId,
+            vocalGender: params.vocalGender,
           },
         });
 

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -42,6 +42,15 @@ export interface GenerationParams {
   hasVocals?: boolean;
   makeInstrumental?: boolean;
   modelVersion?: string;
+  customMode?: boolean;
+  negativeTags?: string;
+  audioWeight?: number;
+  styleWeight?: number;
+  lyricsWeight?: number;
+  weirdness?: number;
+  vocalGender?: 'm' | 'f' | 'any';
+  isBGM?: boolean;
+  audioPrompt?: string;
 }
 
 export interface ExtensionParams {


### PR DESCRIPTION
## Summary
- forward every advanced field from `GenerationService` requests into the provider router calls
- extend router options, shared provider types, and adapters so Suno and Mureka payloads include the new parameters
- update generation unit tests to assert that the expanded option set is routed to Supabase correctly

## Testing
- npx vitest run src/services/generation/__tests__/GenerationService.test.ts src/services/generation/__tests__/generate-mureka.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f247b911c8832fb3c2008c9d32e66f