### PR TITLE
Add ProviderRouter logging context metadata

### DIFF
--- a/src/services/providers/__tests__/router.test.ts
+++ b/src/services/providers/__tests__/router.test.ts
@@ -10,14 +10,17 @@ vi.mock("@/integrations/supabase/client", () => ({
   },
 }));
 
-vi.mock("@/utils/logger", () => ({
-  logger: {
-    info: vi.fn(),
-    error: vi.fn(),
-  },
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
 }));
 
-import { generateMusic } from "../router";
+vi.mock("@/utils/logger", () => ({
+  logger: loggerMock,
+}));
+
+import { generateMusic, isProviderAvailable } from "../router";
 
 const createInvokeResponse = () => ({
   data: { success: true, taskId: "task-1", trackId: "track-1" },
@@ -27,6 +30,9 @@ const createInvokeResponse = () => ({
 describe("Provider router - generateMusic", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    loggerMock.info.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
   });
 
   it("defaults to including vocals when hasVocals is not provided", async () => {
@@ -39,6 +45,11 @@ describe("Provider router - generateMusic", () => {
 
     expect(result).toEqual({ success: true, taskId: "task-1", trackId: "track-1" });
     expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "Routing music generation",
+      "ProviderRouter",
+      { provider: "suno" },
+    );
 
     const [functionName, options] = invokeMock.mock.calls[0];
     expect(functionName).toBe("generate-suno");
@@ -57,9 +68,51 @@ describe("Provider router - generateMusic", () => {
       hasVocals: false,
     });
 
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "Routing music generation",
+      "ProviderRouter",
+      { provider: "suno" },
+    );
+
     const [, options] = invokeMock.mock.calls[0];
     const payload = (options?.body ?? {}) as Record<string, unknown>;
     expect(payload.make_instrumental).toBe(true);
     expect(payload.hasVocals).toBe(false);
+  });
+
+  it("includes track identifiers in log metadata when provided", async () => {
+    invokeMock.mockResolvedValue(createInvokeResponse());
+
+    await generateMusic({
+      provider: "suno",
+      prompt: "Track logging",
+      trackId: "track-99",
+    });
+
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "Routing music generation",
+      "ProviderRouter",
+      { provider: "suno", trackId: "track-99" },
+    );
+  });
+});
+
+describe("Provider router - isProviderAvailable", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    loggerMock.warn.mockReset();
+  });
+
+  it("logs a warning with context when balance retrieval fails", async () => {
+    invokeMock.mockRejectedValue(new Error("network down"));
+
+    const available = await isProviderAvailable("suno");
+
+    expect(available).toBe(false);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "Provider availability check failed",
+      "ProviderRouter",
+      { provider: "suno", error: "network down" },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a shared ProviderRouter logging context and use it for info, warn, and error calls
- sanitize provider router log metadata to avoid undefined entries and capture track identifiers when present
- extend provider router unit tests to verify logging context usage and warn formatting

## Testing
- npx vitest run src/services/providers/__tests__/router.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f250e5ffa0832f9ecd4bcba2bdb935