### PR TITLE
feat: lazy load remaining workspace routes

### DIFF
--- a/src/components/ui/loading-states.tsx
+++ b/src/components/ui/loading-states.tsx
@@ -35,7 +35,7 @@ interface FullPageSpinnerProps {
 
 export const FullPageSpinner = ({ text = 'Загрузка...' }: FullPageSpinnerProps) => {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-screen items-center justify-center" data-testid="full-page-spinner">
       <Spinner size="lg" text={text} />
     </div>
   );

--- a/src/config/workspace-navigation.ts
+++ b/src/config/workspace-navigation.ts
@@ -12,7 +12,14 @@ import {
 import {
   preloadDashboard,
   preloadGenerate,
-} from "@/utils/lazyImports";
+  preloadProjects,
+  preloadMonitoringHub,
+  preloadStudio,
+  preloadDAW,
+  preloadFavorites,
+  preloadSettings,
+  preloadPromptDJPage,
+} from "@/utils/lazyPages";
 
 export type WorkspaceNavRole = "admin";
 
@@ -49,6 +56,7 @@ export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
     label: "Prompt DJ",
     path: "/workspace/prompt-dj",
     icon: Wand2,
+    preload: () => { void preloadPromptDJPage(); },
     isMobilePrimary: true,
   },
   {
@@ -56,6 +64,7 @@ export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
     label: "Studio",
     path: "/workspace/studio",
     icon: Headphones,
+    preload: () => { void preloadStudio(); },
     isMobilePrimary: true,
   },
   {
@@ -63,6 +72,7 @@ export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
     label: "DAW",
     path: "/workspace/daw",
     icon: Headphones,
+    preload: () => { void preloadDAW(); },
     isMobilePrimary: true,
   },
   {
@@ -70,6 +80,7 @@ export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
     label: "Проекты",
     path: "/workspace/projects",
     icon: Library,
+    preload: () => { void preloadProjects(); },
     isMobilePrimary: true,
   },
   {
@@ -77,18 +88,21 @@ export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
     label: "Избранное",
     path: "/workspace/favorites",
     icon: Heart,
+    preload: () => { void preloadFavorites(); },
   },
   {
     id: "monitoring-hub",
     label: "Мониторинг",
     path: "/workspace/monitoring-hub",
     icon: BarChart3,
+    preload: () => { void preloadMonitoringHub(); },
   },
   {
     id: "settings",
     label: "Настройки",
     path: "/workspace/settings",
     icon: Settings,
+    preload: () => { void preloadSettings(); },
   },
 ];
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,34 +13,28 @@ import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";
 import ProtectedRoute from "./components/ProtectedRoute";
 
-// Phase 1 Optimization: Lazy load workspace routes
-import { 
+// Lazy-loaded workspace routes
+import {
   LazyDashboard,
   LazyGenerate,
   LazyLibrary,
   LazyFavorites,
   LazyAnalytics,
   LazySettings,
+  LazyProjects,
+  LazyMonitoringHub,
+  LazyStudio,
+  LazyDAW,
+  LazyProfile,
+  LazyMetrics,
+  LazyAdmin,
+  LazyMonitoring,
+  LazyLyricsLibrary,
+  LazyAudioLibrary,
+  LazyPersonas,
+  LazyPromptDJPage,
+  LazyEdgeFunctionsDebug,
 } from "./utils/lazyPages";
-
-// New hub pages
-import Projects from "./pages/workspace/Projects";
-import MonitoringHub from "./pages/workspace/MonitoringHub";
-
-// Studio page
-import { Studio } from "./pages/workspace/Studio";
-import { DAW } from "./pages/workspace/DAW";
-
-// Still direct imports (will lazy load in Phase 2)
-import Profile from "./pages/workspace/Profile";
-import Metrics from "./pages/workspace/Metrics";
-import Admin from "./pages/workspace/Admin";
-import Monitoring from "./pages/workspace/Monitoring";
-import LyricsLibrary from "./pages/workspace/LyricsLibrary";
-import AudioLibrary from "./pages/workspace/AudioLibrary";
-import Personas from "./pages/workspace/Personas";
-import EdgeFunctionsDebug from "./pages/debug/EdgeFunctionsDebug";
-import { PromptDJPage } from "./pages/workspace/PromptDJPage";
 
 
 export const router = createBrowserRouter(
@@ -55,7 +49,11 @@ export const router = createBrowserRouter(
     },
     {
       path: "/debug/edge-functions",
-      element: <EdgeFunctionsDebug />
+      element: (
+        <Suspense fallback={<FullPageSpinner />}>
+          <LazyEdgeFunctionsDebug />
+        </Suspense>
+      )
     },
     {
       path: "/workspace",
@@ -87,19 +85,35 @@ export const router = createBrowserRouter(
         },
         {
           path: "projects",
-          element: <Projects />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyProjects />
+            </Suspense>
+          )
         },
         {
           path: "studio",
-          element: <Studio />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyStudio />
+            </Suspense>
+          )
         },
         {
           path: "daw",
-          element: <DAW />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyDAW />
+            </Suspense>
+          )
         },
         {
           path: "monitoring-hub",
-          element: <MonitoringHub />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyMonitoringHub />
+            </Suspense>
+          )
         },
         {
           path: "library",
@@ -129,7 +143,11 @@ export const router = createBrowserRouter(
         },
         {
           path: "metrics",
-          element: <Metrics />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyMetrics />
+            </Suspense>
+          )
         },
         {
           path: "settings",
@@ -141,33 +159,57 @@ export const router = createBrowserRouter(
         },
         {
           path: "profile",
-          element: <Profile />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyProfile />
+            </Suspense>
+          )
         },
         {
           path: "admin",
-          element: <Admin />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyAdmin />
+            </Suspense>
+          )
         },
         {
           path: "monitoring",
-          element: <Monitoring />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyMonitoring />
+            </Suspense>
+          )
         },
         {
           path: "lyrics-library",
-          element: <LyricsLibrary />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyLyricsLibrary />
+            </Suspense>
+          )
         },
         {
           path: "audio-library",
-          element: <AudioLibrary />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyAudioLibrary />
+            </Suspense>
+          )
         },
         {
           path: "personas",
-          element: <Personas />
+          element: (
+            <Suspense fallback={<FullPageSpinner />}>
+              <LazyPersonas />
+            </Suspense>
+          )
         },
         {
           path: "prompt-dj",
           element: (
             <Suspense fallback={<FullPageSpinner />}>
-              <PromptDJPage />
+              <LazyPromptDJPage />
             </Suspense>
           )
         },

--- a/src/utils/lazyPages.tsx
+++ b/src/utils/lazyPages.tsx
@@ -73,6 +73,71 @@ export const LazyDashboard = createLazyPage(
   'Dashboard'
 );
 
+export const LazyProjects = createLazyPage(
+  () => import('../pages/workspace/Projects'),
+  'Projects'
+);
+
+export const LazyMonitoringHub = createLazyPage(
+  () => import('../pages/workspace/MonitoringHub'),
+  'MonitoringHub'
+);
+
+export const LazyStudio = createLazyPage(
+  () => import('../pages/workspace/Studio').then(module => ({ default: module.Studio })),
+  'Studio'
+);
+
+export const LazyDAW = createLazyPage(
+  () => import('../pages/workspace/DAW').then(module => ({ default: module.DAW })),
+  'DAW'
+);
+
+export const LazyProfile = createLazyPage(
+  () => import('../pages/workspace/Profile'),
+  'Profile'
+);
+
+export const LazyMetrics = createLazyPage(
+  () => import('../pages/workspace/Metrics'),
+  'Metrics'
+);
+
+export const LazyAdmin = createLazyPage(
+  () => import('../pages/workspace/Admin'),
+  'Admin'
+);
+
+export const LazyMonitoring = createLazyPage(
+  () => import('../pages/workspace/Monitoring'),
+  'Monitoring'
+);
+
+export const LazyLyricsLibrary = createLazyPage(
+  () => import('../pages/workspace/LyricsLibrary'),
+  'LyricsLibrary'
+);
+
+export const LazyAudioLibrary = createLazyPage(
+  () => import('../pages/workspace/AudioLibrary'),
+  'AudioLibrary'
+);
+
+export const LazyPersonas = createLazyPage(
+  () => import('../pages/workspace/Personas'),
+  'Personas'
+);
+
+export const LazyPromptDJPage = createLazyPage(
+  () => import('../pages/workspace/PromptDJPage').then(module => ({ default: module.PromptDJPage })),
+  'PromptDJPage'
+);
+
+export const LazyEdgeFunctionsDebug = createLazyPage(
+  () => import('../pages/debug/EdgeFunctionsDebug'),
+  'EdgeFunctionsDebug'
+);
+
 /**
  * Lazy-loaded компоненты для дополнительной оптимизации
  */
@@ -87,3 +152,11 @@ export const preloadGenerate = () => import('../pages/workspace/Generate');
 export const preloadLibrary = () => import('../pages/workspace/Library');
 export const preloadDashboard = () => import('../pages/workspace/Dashboard');
 export const preloadMusicGenerator = () => import('../components/MusicGeneratorV2');
+export const preloadProjects = () => import('../pages/workspace/Projects');
+export const preloadMonitoringHub = () => import('../pages/workspace/MonitoringHub');
+export const preloadStudio = () => import('../pages/workspace/Studio');
+export const preloadDAW = () => import('../pages/workspace/DAW');
+export const preloadFavorites = () => import('../pages/workspace/Favorites');
+export const preloadAnalytics = () => import('../pages/workspace/Analytics');
+export const preloadSettings = () => import('../pages/workspace/Settings');
+export const preloadPromptDJPage = () => import('../pages/workspace/PromptDJPage');

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -10,6 +10,14 @@ import { Page, expect } from '@playwright/test';
 export async function waitForPageLoad(page: Page) {
   await page.waitForLoadState('networkidle');
   await page.waitForLoadState('domcontentloaded');
+  const spinner = page.locator('[data-testid="full-page-spinner"]');
+  if (await spinner.count()) {
+    try {
+      await spinner.first().waitFor({ state: 'detached', timeout: 10000 });
+    } catch {
+      // Ignore timeout - spinner may represent ongoing background loading
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- lazy load the remaining workspace pages and debug view behind `Suspense` spinners
- add hover preloading hooks for workspace navigation items while centralising lazy exports
- update the E2E helper to wait for the full page spinner so lazy bundles settle before assertions

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors about `any` usage and console statements)*

------
https://chatgpt.com/codex/tasks/task_e_6908a6e5fa98832fbc6049fbc9fdd918