### PR TITLE
Use track operations hook for retry flow and auth context in sidebar

### DIFF
--- a/src/components/workspace/MinimalSidebar.tsx
+++ b/src/components/workspace/MinimalSidebar.tsx
@@ -7,8 +7,7 @@ import type { WorkspaceNavItem } from "@/config/workspace-navigation";
 import { useProviderBalance } from "@/hooks/useProviderBalance";
 import { UserProfileDropdown } from "./UserProfileDropdown";
 import { NotificationsDropdown } from "./NotificationsDropdown";
-import { useEffect, useState } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface MinimalSidebarProps {
   isExpanded: boolean;
@@ -30,13 +29,8 @@ const MinimalSidebar = ({
 }: MinimalSidebarProps) => {
   const location = useLocation();
   const { balance, isLoading: balanceLoading } = useProviderBalance();
-  const [userEmail, setUserEmail] = useState<string>("");
-
-  useEffect(() => {
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      if (user?.email) setUserEmail(user.email);
-    });
-  }, []);
+  const { user } = useAuth();
+  const userEmail = user?.email ?? "";
 
   return (
     <aside

--- a/src/hooks/tracks/useTrackOperations.ts
+++ b/src/hooks/tracks/useTrackOperations.ts
@@ -1,0 +1,111 @@
+import { useCallback, useMemo } from "react";
+import type { Track } from "@/services/api.service";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import { logError, logInfo } from "@/utils/logger";
+
+type RetryFailureReason = "unauthorized" | "error";
+
+export interface RetryTrackGenerationParams {
+  track: Track;
+  onSuccess?: () => void | Promise<void>;
+}
+
+export interface RetryTrackGenerationResult {
+  success: boolean;
+  reason?: RetryFailureReason;
+  error?: Error;
+}
+
+export interface TrackOperations {
+  retryTrackGeneration: (
+    params: RetryTrackGenerationParams
+  ) => Promise<RetryTrackGenerationResult>;
+}
+
+const resolveProvider = (provider: Track["provider"]) =>
+  provider === "suno" || provider === "mureka" ? provider : "suno";
+
+export const useTrackOperations = (): TrackOperations => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const retryTrackGeneration = useCallback<TrackOperations["retryTrackGeneration"]>(
+    async ({ track, onSuccess }) => {
+      if (!user) {
+        toast({
+          title: "Ошибка",
+          description: "Необходима авторизация",
+          variant: "destructive",
+        });
+
+        logInfo("Track retry blocked: no user", "useTrackOperations", {
+          trackId: track.id,
+        });
+
+        return { success: false, reason: "unauthorized" };
+      }
+
+      toast({
+        title: "Повторная генерация",
+        description: "Запускаем генерацию заново...",
+      });
+
+      const provider = resolveProvider(track.provider);
+
+      try {
+        const { GenerationService } = await import("@/services/generation");
+
+        await GenerationService.generate({
+          title: track.title,
+          prompt: track.prompt,
+          provider: provider as any,
+          lyrics: track.lyrics || undefined,
+          hasVocals: track.has_vocals ?? false,
+          styleTags: track.style_tags || undefined,
+        });
+
+        if (onSuccess) {
+          await onSuccess();
+        }
+
+        toast({
+          title: "Успешно",
+          description: "Генерация перезапущена",
+        });
+
+        logInfo("Track retry initiated", "useTrackOperations", {
+          trackId: track.id,
+          provider,
+          userId: user.id,
+        });
+
+        return { success: true };
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+
+        logError("Track retry failed", error, "useTrackOperations", {
+          trackId: track.id,
+          provider,
+          userId: user.id,
+        });
+
+        toast({
+          title: "Ошибка",
+          description: error.message || "Не удалось перезапустить генерацию",
+          variant: "destructive",
+        });
+
+        return { success: false, reason: "error", error };
+      }
+    },
+    [toast, user]
+  );
+
+  return useMemo(
+    () => ({
+      retryTrackGeneration,
+    }),
+    [retryTrackGeneration]
+  );
+};

--- a/src/pages/workspace/Generate.tsx
+++ b/src/pages/workspace/Generate.tsx
@@ -23,6 +23,7 @@ import { normalizeTrack } from "@/utils/trackNormalizer";
 import type { Track } from "@/services/api.service";
 import { TrackDialogsManager } from "@/components/tracks/TrackDialogsManager";
 import { useMusicProjects } from "@/hooks/useMusicProjects";
+import { useTrackOperations } from "@/hooks/tracks/useTrackOperations";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -43,6 +44,7 @@ const Generate = () => {
     pageSize: 25,
   });
   const { projects } = useMusicProjects();
+  const trackOperations = useTrackOperations();
   const [selectedTrack, setSelectedTrack] = useState<Track | null>(null);
   const [showGenerator, setShowGenerator] = useState(false);
 
@@ -164,6 +166,7 @@ const Generate = () => {
                 onCreatePersona={handleCreatePersona}
                 onSelect={setSelectedTrack}
                 isDetailPanelOpen={!!selectedTrack}
+                trackOperations={trackOperations}
               />
               {hasNextPage && (
                 <div className="mt-4 flex justify-center">
@@ -262,6 +265,7 @@ const Generate = () => {
                 onCover={handleCover}
                 onCreatePersona={handleCreatePersona}
                 onSelect={setSelectedTrack}
+                trackOperations={trackOperations}
               />
               {hasNextPage && (
                 <div className="mt-4 flex justify-center">
@@ -342,6 +346,7 @@ const Generate = () => {
           onCover={handleCover}
           onCreatePersona={handleCreatePersona}
           onSelect={setSelectedTrack}
+          trackOperations={trackOperations}
         />
         {hasNextPage && (
           <div className="mt-4 flex justify-center">

--- a/tests/unit/hooks/useTrackOperations.test.ts
+++ b/tests/unit/hooks/useTrackOperations.test.ts
@@ -1,0 +1,171 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useTrackOperations } from "@/hooks/tracks/useTrackOperations";
+import { createMockTrack } from "@/test/utils/test-helpers";
+import type { Track } from "@/services/api.service";
+
+const mockUseAuth = vi.fn();
+const toastMock = vi.fn();
+const generateMock = vi.fn();
+const logInfoMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/services/generation", () => ({
+  GenerationService: {
+    generate: (...args: unknown[]) => generateMock(...args),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logInfo: (...args: unknown[]) => logInfoMock(...args),
+  logError: (...args: unknown[]) => logErrorMock(...args),
+}));
+
+const createAuthValue = (user: { id: string; email?: string } | null) => ({
+  user,
+  userId: user?.id ?? null,
+  session: null,
+  isLoading: false,
+  refresh: vi.fn(),
+});
+
+describe("useTrackOperations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReset();
+    toastMock.mockReset();
+    generateMock.mockReset();
+    logInfoMock.mockReset();
+    logErrorMock.mockReset();
+  });
+
+  it("blocks retry when user is not authenticated", async () => {
+    const track = createMockTrack({ status: "failed" });
+    mockUseAuth.mockReturnValue(createAuthValue(null));
+
+    const { result } = renderHook(() => useTrackOperations());
+
+    await act(async () => {
+      const outcome = await result.current.retryTrackGeneration({
+        track: track as unknown as Track,
+      });
+
+      expect(outcome.success).toBe(false);
+      expect(outcome.reason).toBe("unauthorized");
+    });
+
+    expect(generateMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Ошибка",
+        variant: "destructive",
+      })
+    );
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "Track retry blocked: no user",
+      "useTrackOperations",
+      expect.objectContaining({ trackId: track.id })
+    );
+  });
+
+  it("restarts generation successfully", async () => {
+    const track = createMockTrack({
+      status: "failed",
+      provider: "suno",
+      lyrics: "Test lyrics",
+      style_tags: ["pop", "electro"],
+      has_vocals: true,
+    });
+    const onSuccess = vi.fn();
+
+    mockUseAuth.mockReturnValue(
+      createAuthValue({ id: "user-123", email: "user@example.com" })
+    );
+    generateMock.mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useTrackOperations());
+
+    await act(async () => {
+      const outcome = await result.current.retryTrackGeneration({
+        track: track as unknown as Track,
+        onSuccess,
+      });
+
+      expect(outcome.success).toBe(true);
+    });
+
+    expect(generateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: track.title,
+        prompt: track.prompt,
+        provider: "suno",
+        hasVocals: true,
+        lyrics: track.lyrics,
+        styleTags: track.style_tags,
+      })
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(toastMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ title: "Повторная генерация" })
+    );
+    expect(toastMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ title: "Успешно" })
+    );
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "Track retry initiated",
+      "useTrackOperations",
+      expect.objectContaining({
+        trackId: track.id,
+        provider: "suno",
+        userId: "user-123",
+      })
+    );
+  });
+
+  it("handles generation errors and surfaces feedback", async () => {
+    const track = createMockTrack({ status: "failed", provider: "mureka" });
+    const error = new Error("Generation failed");
+
+    mockUseAuth.mockReturnValue(
+      createAuthValue({ id: "user-999", email: "tester@example.com" })
+    );
+    generateMock.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useTrackOperations());
+
+    await act(async () => {
+      const outcome = await result.current.retryTrackGeneration({
+        track: track as unknown as Track,
+      });
+
+      expect(outcome.success).toBe(false);
+      expect(outcome.reason).toBe("error");
+      expect(outcome.error).toBe(error);
+    });
+
+    expect(generateMock).toHaveBeenCalled();
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "Track retry failed",
+      error,
+      "useTrackOperations",
+      expect.objectContaining({ trackId: track.id, provider: "mureka" })
+    );
+    expect(toastMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: "Ошибка",
+        variant: "destructive",
+        description: error.message,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace the MinimalSidebar user lookup with the shared AuthContext
- extract track retry generation into a reusable useTrackOperations hook and inject it via TracksList props
- cover the new hook with targeted unit tests

## Testing
- npx vitest run tests/unit/hooks/useTrackOperations.test.ts
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_6908ac68edd8832f997c512b3a06c34e